### PR TITLE
docs: Spec artifact consistency audit for F17/F18

### DIFF
--- a/specs/020-embeddings-api/walkthrough.md
+++ b/specs/020-embeddings-api/walkthrough.md
@@ -1,78 +1,186 @@
 # F17: Embeddings API — Code Walkthrough
 
-> A junior-developer-friendly guide to how the `/v1/embeddings` endpoint works in Nexus.
+**Feature**: Embeddings API (F17)  
+**Audience**: Junior developers joining the project  
+**Last Updated**: 2025-07-18
 
-## 1. Architecture Overview
+---
 
-Nexus exposes an OpenAI-compatible embeddings endpoint at `POST /v1/embeddings`. It follows the same patterns as chat completions:
+## Table of Contents
+
+1. [The Big Picture](#the-big-picture)
+2. [File Structure](#file-structure)
+3. [File 1: api/embeddings.rs — The Intake Desk](#file-1-apiembeddingsrs--the-intake-desk)
+4. [File 2: agent/mod.rs — The Translation Contract](#file-2-agentmodrs--the-translation-contract)
+5. [File 3: agent/openai.rs — The Express Counter](#file-3-agentopenairs--the-express-counter)
+6. [File 4: agent/ollama.rs — The Specialist Window](#file-4-agentollamars--the-specialist-window)
+7. [File 5: api/headers.rs — The Return Label](#file-5-apiheadersrs--the-return-label)
+8. [Understanding the Tests](#understanding-the-tests)
+9. [Key Rust Concepts](#key-rust-concepts)
+10. [Common Patterns in This Codebase](#common-patterns-in-this-codebase)
+11. [Next Steps](#next-steps)
+
+---
+
+## The Big Picture
+
+Imagine Nexus is a **translation bureau**. Clients walk in with documents (text) and say "I need these translated into coordinates" — that is, converted from human-readable words into dense numeric vectors that machines can compare, cluster, and search. The bureau doesn't do the translation itself; it has specialist translators in the back (OpenAI, Ollama) who each speak different protocols. The bureau's job is to accept the request in a standard format, find the right translator, hand off the work, and return the result — all without the client knowing which translator was used.
+
+That's what the **Embeddings API** (F17) does. It exposes a single `POST /v1/embeddings` endpoint that accepts OpenAI-formatted requests, routes them to the right backend via the same intelligent router used for chat completions, and returns OpenAI-formatted responses — regardless of whether the actual work was done by OpenAI's cloud API or a local Ollama instance.
+
+### What Problem Does This Solve?
+
+Without F17, a developer using Nexus for RAG (retrieval-augmented generation) or semantic search would need to maintain separate client configurations for each embedding backend. If their Ollama instance went down, they'd need to manually switch to OpenAI. If they wanted to keep sensitive documents local, they'd need to manage that routing themselves.
+
+F17 makes embedding requests **backend-agnostic** — the same URL works regardless of which backend is available, and the existing router handles health checks, capability matching, and privacy zones automatically.
+
+### How F17 Fits Into Nexus
 
 ```
-Client  ──POST /v1/embeddings──▶  Axum Handler  ──Router──▶  Agent  ──▶  Backend
-                                  (embeddings.rs)             (NII trait)   (Ollama / OpenAI)
+┌──────────────────────────────────────────────────────────────────────────┐
+│                              Nexus                                      │
+│                                                                         │
+│  Client Request                                                         │
+│    │  POST /v1/embeddings                                               │
+│    │  {                                                                  │
+│    │    "model": "text-embedding-ada-002",                               │
+│    │    "input": ["hello world", "goodbye"]                              │
+│    │  }                                                                  │
+│    ▼                                                                    │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ① Axum handler: handle()                          ◄── F17    │    │
+│  │     Validates and normalizes the request:                      │    │
+│  │     • Deserialize JSON → EmbeddingRequest                     │    │
+│  │     • EmbeddingInput::into_vec() normalizes single/batch      │    │
+│  │     • Validate: non-empty, ≤ 2048 batch size                  │    │
+│  │     • Estimate tokens: sum(chars / 4)                         │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ② Router::select_backend()                                    │    │
+│  │     Same router used by chat completions:                      │    │
+│  │     • Build RequestRequirements (no vision/tools/json needed)  │    │
+│  │     • Alias resolution, capability filtering, scoring          │    │
+│  │     • Returns backend + cost estimate                          │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ③ Capability gate                                 ◄── F17    │    │
+│  │     • Registry::get_agent() → get NII agent                   │    │
+│  │     • Check agent.profile().capabilities.embeddings == true    │    │
+│  │     • Track pending: increment_pending / decrement_pending     │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ④ agent.embeddings(model, input)                  ◄── F17    │    │
+│  │     Backend-specific HTTP call:                                │    │
+│  │     • OpenAI: POST /v1/embeddings (batch, Bearer auth)        │    │
+│  │     • Ollama: POST /api/embed (per-input iteration)           │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ⑤ Build response                                 ◄── F17    │    │
+│  │     • Vec<Vec<f32>> → EmbeddingResponse (OpenAI format)       │    │
+│  │     • Inject X-Nexus-* transparent headers                     │    │
+│  │     • Return 200 OK with JSON body                             │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                         │
+│  Data Flow: Request JSON → EmbeddingRequest (types)                    │
+│             → RequestRequirements (routing input)                      │
+│             → InferenceAgent::embeddings() (backend call)              │
+│             → EmbeddingResponse (OpenAI format)                        │
+│             → X-Nexus-* headers (routing metadata)                     │
+└──────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Key architectural concepts:**
+### Key Design Decisions
 
-- **NII (Nexus Inference Interface):** Every backend implements the `InferenceAgent` trait. The `embeddings()` method is an *optional capability* — it returns `AgentError::Unsupported` by default. Only agents that actually support embeddings (OpenAI, Ollama) override it.
-- **Unified Router:** The same `Router::select_backend()` used for chat completions also handles embedding requests. The handler builds `RequestRequirements` and lets the router pick the best backend.
-- **Capability gating:** After routing, the handler checks `agent.profile().capabilities.embeddings` before calling `agent.embeddings()`. This prevents routing to a backend that advertises a model but can't embed it.
+| Decision | Why |
+|----------|-----|
+| OpenAI format as canonical wire format | Any OpenAI-compatible client works out of the box. Backend-specific formats (Ollama's `/api/embed`) are translated by the agent layer |
+| `embeddings()` is an optional trait method | New agent types work without embeddings support. They return `AgentError::Unsupported` by default until explicitly overridden |
+| Capability gate *after* routing | Router selects by model availability; the `capabilities.embeddings` check is a second-stage safety net |
+| Batch size capped at 2048 | Matches OpenAI's limit. Prevents resource exhaustion from unbounded input arrays |
+| `model` parameter forwarded to agent | Agent uses the client's requested model, not a hardcoded default. Supports multiple embedding models per backend |
+| Pending request tracking | `increment_pending` / `decrement_pending` feeds load-aware routing so embedding requests count toward backend load |
 
-## 2. Request Flow
+---
 
-Here's what happens step-by-step when a client sends `POST /v1/embeddings`:
+## File Structure
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  1. Axum deserializes JSON into EmbeddingRequest                │
-│  2. Validate input is non-empty                                 │
-│  3. Estimate tokens: sum(input.len() / 4) — chars/4 heuristic  │
-│  4. Build RequestRequirements (no vision/tools/json needed)     │
-│  5. Router::select_backend() → picks backend by model + health │
-│  6. Registry::get_agent() → get the NII agent for that backend │
-│  7. Check agent.profile().capabilities.embeddings == true       │
-│  8. agent.embeddings(input_texts) → backend-specific HTTP call  │
-│  9. Build OpenAI-compatible EmbeddingResponse                   │
-│ 10. Inject X-Nexus-* transparent headers                        │
-└─────────────────────────────────────────────────────────────────┘
+src/api/
+├── embeddings.rs            ← F17: Handler + types (334 lines, 8 tests)  NEW
+
+src/agent/
+├── mod.rs                   ← F17: embeddings() trait method (431 lines, 0 F17 tests)  MODIFIED
+├── openai.rs                ← F17: OpenAI embeddings impl (876 lines, in agent tests)  MODIFIED
+├── ollama.rs                ← F17: Ollama embeddings impl (844 lines, in agent tests)  MODIFIED
+
+src/api/
+├── headers.rs               ← F12: NexusTransparentHeaders (208 lines, 2 tests)  EXISTING
+
+tests/
+├── embeddings_test.rs       ← F17: Integration tests (146 lines, 5 tests)  NEW
 ```
 
-### Error cases at each step
+**F17 Contribution**: 1 new handler file (`embeddings.rs`), 1 new integration test file, 3 modified files (trait + 2 agents). ~480 lines added, 8 unit tests, 5 integration tests.
 
-| Step | Failure | HTTP Status |
-|------|---------|-------------|
-| 1 | Invalid JSON | 400 Bad Request |
-| 2 | Empty input array | 400 Bad Request |
-| 5 | Model not found | 404 Not Found |
-| 5 | No healthy backend | 503 Service Unavailable |
-| 6 | No agent registered | 502 Bad Gateway |
-| 7 | Agent doesn't support embeddings | 503 Service Unavailable |
-| 8 | Backend returns error | Mapped from `AgentError` |
+---
 
-## 3. Key Files
+## File 1: api/embeddings.rs — The Intake Desk
 
-### `src/api/embeddings.rs` — Handler + Types
+**Purpose**: The front desk of the translation bureau — accepts embedding requests, validates them, routes to the right translator, and assembles the response.  
+**Lines**: 334  |  **Tests**: 8  |  **Status**: NEW
 
-This is the entry point. It defines the request/response types and the handler function.
+### Why Does This Exist?
 
-**Types:**
+Every embedding request enters Nexus through this handler. It's responsible for the entire lifecycle: deserializing the request, validating input, routing to a backend, delegating to the right agent, building the OpenAI-compatible response, and injecting transparent headers. Without this file, Nexus would have no embeddings endpoint.
+
+The critical design constraint: **stay OpenAI-compatible**. The request and response formats must match OpenAI's `/v1/embeddings` spec exactly, so any client library (LangChain, LlamaIndex, etc.) works without modification.
+
+### The Types
 
 ```rust
-// Input accepts both single string and array (OpenAI-compatible)
-#[derive(Deserialize, Serialize)]
+// src/api/embeddings.rs (lines 17–65)
+
+/// Input format — OpenAI accepts both a single string and an array
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum EmbeddingInput {
     Single(String),
     Batch(Vec<String>),
 }
 
-// The request — mirrors OpenAI's format
+impl EmbeddingInput {
+    /// Convert to a Vec<String> regardless of variant.
+    pub fn into_vec(self) -> Vec<String> {
+        match self {
+            EmbeddingInput::Single(s) => vec![s],
+            EmbeddingInput::Batch(v) => v,
+        }
+    }
+}
+
+/// Embedding request matching OpenAI format.
 pub struct EmbeddingRequest {
     pub model: String,
     pub input: EmbeddingInput,
-    pub encoding_format: Option<String>,  // optional, e.g. "float"
+    pub encoding_format: Option<String>,  // e.g. "float"
 }
 
-// The response — also mirrors OpenAI's format
+/// A single embedding object in the response.
+pub struct EmbeddingObject {
+    pub object: String,       // always "embedding"
+    pub embedding: Vec<f32>,  // the actual vector
+    pub index: usize,         // position in batch
+}
+
+/// Embedding response matching OpenAI format.
 pub struct EmbeddingResponse {
     pub object: String,            // always "list"
     pub data: Vec<EmbeddingObject>,
@@ -81,52 +189,245 @@ pub struct EmbeddingResponse {
 }
 ```
 
-`EmbeddingInput::into_vec()` normalizes both variants into `Vec<String>` so the rest of the handler doesn't care which format the client used.
+`EmbeddingInput` uses `#[serde(untagged)]` to accept both `"input": "hello"` and `"input": ["hello", "world"]` — the two formats OpenAI supports. The `into_vec()` method normalizes both into `Vec<String>` so the handler doesn't care which format the client used.
 
-**Handler highlights:**
+### The Handler
 
 ```rust
-// Token estimation — simple chars/4 heuristic
-let estimated_tokens: u32 = input_texts.iter().map(|s| s.len() as u32 / 4).sum();
+// src/api/embeddings.rs (lines 68–189)
 
-// Capability gate — checked AFTER routing
-if !agent.profile().capabilities.embeddings {
-    return Err(ApiError::service_unavailable(...));
+const MAX_EMBEDDING_BATCH_SIZE: usize = 2048;
+
+pub async fn handle(
+    State(state): State<Arc<AppState>>,
+    _headers: HeaderMap,
+    Json(request): Json<EmbeddingRequest>,
+) -> Result<Response, ApiError> {
+    info!(model = %request.model, "Embedding request");
+
+    // ── Validation ──────────────────────────────────────────────
+    let input_texts = request.input.into_vec();
+    if input_texts.is_empty() {
+        return Err(ApiError::bad_request("Input must not be empty"));
+    }
+    if input_texts.len() > MAX_EMBEDDING_BATCH_SIZE {
+        return Err(ApiError::bad_request(&format!(
+            "Batch size {} exceeds maximum of {}",
+            input_texts.len(), MAX_EMBEDDING_BATCH_SIZE
+        )));
+    }
+
+    // ── Token estimation for routing ────────────────────────────
+    let estimated_tokens: u32 = input_texts.iter().map(|s| s.len() as u32 / 4).sum();
+
+    // ── Route to a backend ──────────────────────────────────────
+    let requirements = RequestRequirements {
+        model: request.model.clone(),
+        estimated_tokens,
+        needs_vision: false,       // embeddings don't need any
+        needs_tools: false,        // special capabilities —
+        needs_json_mode: false,    // just model availability
+        prefers_streaming: false,
+    };
+
+    let routing_result = state.router.select_backend(&requirements, None)
+        .map_err(|e| match e {
+            RoutingError::ModelNotFound { model } =>
+                ApiError::model_not_found(&model, &[]),
+            RoutingError::NoHealthyBackend { model } =>
+                ApiError::service_unavailable(&format!(
+                    "No healthy backend available for model '{}'", model)),
+            _ => ApiError::bad_gateway(&format!("Routing error: {}", e)),
+        })?;
+
+    let backend = &routing_result.backend;
+
+    // ── Capability gate ─────────────────────────────────────────
+    let agent = state.registry.get_agent(&backend.id).ok_or_else(|| {
+        ApiError::bad_gateway(&format!("No agent registered for backend '{}'", backend.id))
+    })?;
+
+    if !agent.profile().capabilities.embeddings {
+        return Err(ApiError::service_unavailable(&format!(
+            "Backend '{}' does not support embeddings", backend.id
+        )));
+    }
+
+    // ── Delegate to agent (with pending tracking) ───────────────
+    let _ = state.registry.increment_pending(&backend.id);
+
+    let vectors = agent.embeddings(&request.model, input_texts).await
+        .map_err(|e| {
+            let _ = state.registry.decrement_pending(&backend.id);
+            ApiError::from_agent_error(e)
+        })?;
+
+    let _ = state.registry.decrement_pending(&backend.id);
+
+    // ── Build OpenAI-compatible response ────────────────────────
+    let data: Vec<EmbeddingObject> = vectors.into_iter().enumerate()
+        .map(|(i, embedding)| EmbeddingObject {
+            object: "embedding".to_string(),
+            embedding,
+            index: i,
+        })
+        .collect();
+
+    let response = EmbeddingResponse {
+        object: "list".to_string(),
+        data,
+        model: request.model,
+        usage: EmbeddingUsage {
+            prompt_tokens: estimated_tokens,
+            total_tokens: estimated_tokens,
+        },
+    };
+
+    let mut resp = Json(response).into_response();
+
+    // ── Inject X-Nexus-* transparent headers ────────────────────
+    let privacy_zone = agent.profile().privacy_zone;
+    let nexus_headers = NexusTransparentHeaders::new(
+        backend.id.clone(),
+        backend.backend_type,
+        RouteReason::CapabilityMatch,
+        privacy_zone,
+        routing_result.cost_estimated,
+    );
+    nexus_headers.inject_into_response(&mut resp);
+
+    Ok(resp)
 }
-
-// Delegate to the agent — backend-specific logic lives there
-let vectors = agent.embeddings(input_texts.clone()).await?;
 ```
 
-### `src/agent/mod.rs` — InferenceAgent Trait
+Let's trace through the handler step by step:
 
-The trait defines `embeddings()` as an optional method with a default that returns `Unsupported`:
+1. **Validation**: Normalize input via `into_vec()`, reject empty input and batches larger than 2048.
+2. **Token estimation**: The `chars / 4` heuristic — same one used throughout Nexus. This is for routing decisions, not billing.
+3. **Routing**: Build `RequestRequirements` with all capability flags set to `false` (embeddings don't need vision, tools, or JSON mode). The router picks a backend based on model availability and health.
+4. **Capability gate**: After routing finds a backend, verify its agent actually supports embeddings. This two-stage approach means the router stays generic.
+5. **Pending tracking**: `increment_pending()` before the call, `decrement_pending()` after (including on error). This feeds load-aware routing so embedding requests count toward backend load.
+6. **Delegation**: Call `agent.embeddings(&request.model, input_texts)` — the model parameter is forwarded from the client request, not hardcoded.
+7. **Response assembly**: Convert `Vec<Vec<f32>>` into `EmbeddingResponse` with proper indexing and token usage.
+8. **Header injection**: Add X-Nexus-* headers so clients can see which backend served the request.
+
+### Key Tests
 
 ```rust
-#[async_trait]
-pub trait InferenceAgent: Send + Sync + 'static {
-    // ... required methods (health_check, list_models, chat_completion, etc.)
-
-    /// Default: returns Unsupported. Override in agents that support embeddings.
-    async fn embeddings(&self, _input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentError> {
-        Err(AgentError::Unsupported("embeddings"))
+#[test]
+fn embedding_request_deserialize_single_input() {
+    let json = r#"{"model":"text-embedding-ada-002","input":"hello world"}"#;
+    let req: EmbeddingRequest = serde_json::from_str(json).unwrap();
+    assert_eq!(req.model, "text-embedding-ada-002");
+    match &req.input {
+        EmbeddingInput::Single(s) => assert_eq!(s, "hello world"),
+        _ => panic!("Expected Single variant"),
     }
 }
+
+#[test]
+fn embedding_response_serialization_matches_openai() {
+    let response = EmbeddingResponse {
+        object: "list".to_string(),
+        data: vec![EmbeddingObject {
+            object: "embedding".to_string(),
+            embedding: vec![0.1, 0.2, 0.3],
+            index: 0,
+        }],
+        model: "text-embedding-ada-002".to_string(),
+        usage: EmbeddingUsage { prompt_tokens: 10, total_tokens: 10 },
+    };
+
+    let json = serde_json::to_value(&response).unwrap();
+    assert_eq!(json["object"], "list");
+    assert_eq!(json["data"][0]["object"], "embedding");
+    assert_eq!(json["usage"]["prompt_tokens"], 10);
+    // ◄── Verifies wire format matches OpenAI exactly
+}
+
+#[test]
+fn embedding_object_serialization() {
+    let obj = EmbeddingObject {
+        object: "embedding".to_string(),
+        embedding: vec![0.0; 1536],  // standard OpenAI dimension
+        index: 0,
+    };
+    let json = serde_json::to_value(&obj).unwrap();
+    assert_eq!(json["embedding"].as_array().unwrap().len(), 1536);
+    // ◄── 1536-dim vectors serialize without truncation
+}
 ```
 
-This means you can add a new agent type without worrying about embeddings — it just won't support them until you explicitly override the method.
+The tests focus on serialization correctness — verifying that Nexus produces JSON that any OpenAI client library can parse. The `embedding_object_serialization` test with a 1536-dimensional vector is particularly important since that's OpenAI's standard embedding size.
 
-### `src/agent/openai.rs` — OpenAI Agent
+---
 
-OpenAI supports native batch embedding. The agent sends all inputs in a single request:
+## File 2: agent/mod.rs — The Translation Contract
+
+**Purpose**: Defines the contract that every translator (agent) must follow — including the optional `embeddings()` method.  
+**Lines**: 431  |  **F17 Addition**: ~10 lines  |  **Status**: MODIFIED
+
+### Why Does This Exist?
+
+The `InferenceAgent` trait is the heart of Nexus's backend abstraction. Every backend type (Ollama, OpenAI, LM Studio, etc.) implements this trait. F17 adds `embeddings()` as an **optional capability** — agents that don't support embeddings get a free default implementation that returns `AgentError::Unsupported`.
+
+This is the "translation contract" — it defines what services the bureau offers, and each translator decides which services they can perform.
+
+### The Trait Method
 
 ```rust
-async fn embeddings(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentError> {
+// src/agent/mod.rs (lines 209–219)
+
+/// Generate embeddings for input text (F17: Embeddings, v0.4).
+///
+/// Default implementation returns `Unsupported`. Override in OpenAIAgent
+/// and backends that support /v1/embeddings endpoint.
+async fn embeddings(
+    &self,
+    _model: &str,
+    _input: Vec<String>,
+) -> Result<Vec<Vec<f32>>, AgentError> {
+    Err(AgentError::Unsupported("embeddings"))
+}
+```
+
+Key design decisions in this signature:
+
+- **`_model: &str`**: The model name is forwarded from the client request. This lets agents support multiple embedding models (e.g., `text-embedding-ada-002` vs `text-embedding-3-small`) without hardcoding.
+- **`_input: Vec<String>`**: Already normalized by the handler — agents don't need to handle single-vs-batch.
+- **`Vec<Vec<f32>>`**: One vector per input string. The handler wraps these in `EmbeddingObject` structs for the response.
+- **Default returns `Unsupported`**: New agent types (e.g., `GenericOpenAIAgent`) automatically decline embedding requests. The handler's capability gate catches this before the call is even made.
+
+### Key Tests
+
+The trait method itself has no tests — it's tested indirectly through the concrete implementations in `openai.rs` and `ollama.rs`, and through the integration tests that exercise the full request flow.
+
+---
+
+## File 3: agent/openai.rs — The Express Counter
+
+**Purpose**: The OpenAI agent's implementation of `embeddings()` — sends the entire batch to OpenAI's cloud API in a single HTTP request.  
+**Lines**: 876  |  **F17 Addition**: ~70 lines  |  **Status**: MODIFIED
+
+### Why Does This Exist?
+
+OpenAI's `/v1/embeddings` endpoint natively supports batch embedding — you send an array of strings and get back an array of vectors. This is the "express counter" of the translation bureau: hand over everything at once, get everything back at once. No iteration needed.
+
+### The Implementation
+
+```rust
+// src/agent/openai.rs (lines 357–426)
+
+async fn embeddings(
+    &self,
+    model: &str,
+    input: Vec<String>,
+) -> Result<Vec<Vec<f32>>, AgentError> {
     let url = format!("{}/v1/embeddings", self.base_url);
 
     let body = serde_json::json!({
-        "model": "text-embedding-ada-002",
-        "input": input,   // ← entire batch in one request
+        "model": model,        // ◄── forwarded from client request
+        "input": input,        // ◄── entire batch in one request
     });
 
     let response = self.client
@@ -135,38 +436,49 @@ async fn embeddings(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentErr
         .json(&body)
         .timeout(Duration::from_secs(60))
         .send()
-        .await?;
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                AgentError::Timeout(60000)
+            } else {
+                AgentError::Network(e.to_string())
+            }
+        })?;
 
-    // Parse response.data[].embedding arrays into Vec<Vec<f32>>
-    // ...
-}
-```
-
-**Key details:**
-- Uses Bearer token authentication from config
-- 60-second timeout
-- Parses `response.data[i].embedding` arrays into `Vec<f32>` vectors
-- The profile advertises `capabilities.embeddings: true`
-
-### `src/agent/ollama.rs` — Ollama Agent
-
-Ollama's `/api/embed` endpoint doesn't support batch input the same way, so the agent iterates per input:
-
-```rust
-async fn embeddings(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentError> {
-    let mut results = Vec::with_capacity(input.len());
-
-    for text in &input {
-        let url = format!("{}/api/embed", self.base_url);
-        let body = serde_json::json!({
-            "model": "all-minilm",
-            "input": text,   // ← one input at a time
+    let status = response.status();
+    if !status.is_success() {
+        let error_body = response.text().await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(AgentError::Upstream {
+            status: status.as_u16(),
+            message: error_body,
         });
+    }
 
-        let response = self.client.post(&url).json(&body).send().await?;
+    let body: serde_json::Value = response.json().await.map_err(|e| {
+        AgentError::InvalidResponse(format!(
+            "Failed to parse OpenAI embeddings response: {}", e
+        ))
+    })?;
 
-        // Ollama returns { "embeddings": [[...]] }
-        let vector = parse_ollama_embeddings(response)?;
+    let data = body["data"].as_array().ok_or_else(|| {
+        AgentError::InvalidResponse(
+            "Missing data array in OpenAI embeddings response".to_string(),
+        )
+    })?;
+
+    let mut results = Vec::with_capacity(data.len());
+    for item in data {
+        let embedding = item["embedding"].as_array().ok_or_else(|| {
+            AgentError::InvalidResponse(
+                "Missing embedding array in response item".to_string(),
+            )
+        })?;
+
+        let vector: Vec<f32> = embedding.iter()
+            .filter_map(|v| v.as_f64().map(|f| f as f32))
+            .collect();
+
         results.push(vector);
     }
 
@@ -174,204 +486,421 @@ async fn embeddings(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentErr
 }
 ```
 
-**Key differences from OpenAI:**
-- Uses Ollama's native `/api/embed` endpoint (not `/v1/embeddings`)
-- Iterates per input text (N HTTP requests for N inputs)
-- Response format is `{ "embeddings": [[...]] }` — different from OpenAI's `{ "data": [{"embedding": [...]}] }`
-- No auth header needed (local backend)
+Let's trace through this implementation:
 
-### `src/api/headers.rs` — X-Nexus-* Transparent Headers
+1. **URL construction**: Appends `/v1/embeddings` to the configured base URL.
+2. **Body**: Uses the `model` parameter from the client request (not hardcoded). Sends the entire `input` array in one request — OpenAI handles batching natively.
+3. **Authentication**: Bearer token from the agent's configured API key.
+4. **Timeout**: 60 seconds — embedding large batches can take time.
+5. **Error handling**: Distinguishes timeout (`AgentError::Timeout`) from network errors (`AgentError::Network`) from upstream failures (`AgentError::Upstream` with status code).
+6. **Response parsing**: Navigates `response.data[i].embedding` arrays, converting each `f64` JSON number to `f32`.
 
-After building the response, the handler injects routing metadata headers:
+### Key Tests
 
-```rust
-let nexus_headers = NexusTransparentHeaders::new(
-    backend.id.clone(),         // X-Nexus-Backend: "ollama-local"
-    backend.backend_type,       // X-Nexus-Backend-Type: "local" or "cloud"
-    RouteReason::CapabilityMatch,  // X-Nexus-Route-Reason
-    privacy_zone,               // X-Nexus-Privacy-Zone: "restricted" or "open"
-    routing_result.cost_estimated, // X-Nexus-Cost-Estimated (cloud only)
-);
-nexus_headers.inject_into_response(&mut resp);
-```
+The OpenAI agent's embedding tests live in the agent test module and use mock HTTP servers to verify:
+- Successful batch embedding returns the correct number of vectors
+- Authentication headers are included in the request
+- Timeout and error responses are properly mapped to `AgentError` variants
 
-These headers let clients see *which* backend served the request without Nexus modifying the JSON response body (Constitution Principle III).
+---
 
-## 4. Design Decisions
+## File 4: agent/ollama.rs — The Specialist Window
 
-### Why OpenAI format as standard?
+**Purpose**: The Ollama agent's implementation of `embeddings()` — sends one request per input text because Ollama's native API doesn't support batch embedding.  
+**Lines**: 844  |  **F17 Addition**: ~70 lines  |  **Status**: MODIFIED
 
-Nexus uses OpenAI's embedding request/response format as the canonical wire format. This means any OpenAI-compatible client works out of the box. Backend-specific formats (like Ollama's `/api/embed`) are translated by the agent layer.
+### Why Does This Exist?
 
-### Why capability-based routing?
+Ollama uses a different endpoint (`/api/embed`) with a different response format (`{ "embeddings": [[...]] }`). It also doesn't natively support batch input the way OpenAI does. This is the "specialist window" — it handles one document at a time, carefully, using Ollama's native protocol.
 
-Not every backend supports embeddings. The `AgentCapabilities.embeddings` flag lets the system know which backends can handle embedding requests. This is checked *after* routing (not during) because the router selects based on model availability, and the capability check is a second-stage filter.
+### The Implementation
 
 ```rust
-// In AgentProfile — set per agent type
-pub struct AgentCapabilities {
-    pub embeddings: bool,       // OpenAI: true, Ollama: true, Generic: false
-    pub model_lifecycle: bool,
-    pub token_counting: bool,
-    pub resource_monitoring: bool,
-}
-```
+// src/agent/ollama.rs (lines 291–357)
 
-### Why does Ollama iterate per-input?
+async fn embeddings(
+    &self,
+    model: &str,
+    input: Vec<String>,
+) -> Result<Vec<Vec<f32>>, AgentError> {
+    let mut results = Vec::with_capacity(input.len());
 
-Ollama's `/api/embed` endpoint accepts a single input string and returns one embedding. To support batch requests (OpenAI format allows `"input": ["a", "b", "c"]`), the Ollama agent sends N sequential requests. This is a trade-off:
-
-- **Pro:** Works with Ollama's native API without changes
-- **Con:** N requests for N inputs (higher latency for large batches)
-- **Future:** If Ollama adds batch support, the agent can be updated without changing the handler
-
-### Why chars/4 for token estimation?
-
-The handler estimates tokens as `text.len() / 4` (the standard heuristic used throughout Nexus). This is used for routing decisions, not billing. OpenAI's agent has exact tiktoken counting, but the embedding handler uses the heuristic for simplicity since exact token counts aren't critical for embedding routing.
-
-### Why X-Nexus-* headers?
-
-Nexus never modifies the JSON response body (OpenAI compatibility). All routing metadata goes into HTTP headers. The embeddings endpoint uses `RouteReason::CapabilityMatch` since the backend was selected for having the requested model and embedding capability.
-
-## 5. Testing
-
-### Unit Tests (8 tests in `src/api/embeddings.rs`)
-
-These test serialization/deserialization of the embedding types:
-
-| Test | What it verifies |
-|------|-----------------|
-| `embedding_request_deserialize_single_input` | `"input": "hello"` parses as `Single` variant |
-| `embedding_request_deserialize_batch_input` | `"input": ["a","b"]` parses as `Batch` variant |
-| `embedding_request_with_encoding_format` | Optional `encoding_format` field |
-| `embedding_input_into_vec_single` | `Single("x").into_vec()` → `vec!["x"]` |
-| `embedding_input_into_vec_batch` | `Batch(["a","b"]).into_vec()` → `vec!["a","b"]` |
-| `embedding_response_serialization_matches_openai` | Response JSON matches OpenAI format |
-| `embedding_response_roundtrip` | Serialize → deserialize → same values |
-| `embedding_object_serialization` | 1536-dim vector serializes correctly |
-
-### Integration Tests (5 tests in `tests/embeddings_test.rs`)
-
-These test the full HTTP stack with mock backends:
-
-| Test | What it verifies |
-|------|-----------------|
-| `embeddings_route_exists` | `POST /v1/embeddings` returns non-404/405 |
-| `embeddings_returns_valid_response` | With mock backend, returns 200/503/502 |
-| `embeddings_model_not_found_returns_error` | Unknown model → 404 |
-| `embeddings_batch_input_accepted` | Array input format accepted (not 400) |
-| `embeddings_invalid_json_returns_422` | Malformed JSON → 400 |
-
-### Running the tests
-
-```bash
-# All embedding tests (unit + integration)
-cargo test embeddings
-
-# Unit tests only
-cargo test api::embeddings::tests
-
-# Integration tests only
-cargo test --test embeddings_test
-
-# Single test
-cargo test embedding_request_deserialize_single_input
-```
-
-## 6. Common Modifications
-
-### Adding embeddings support to a new agent
-
-Say you're adding a new agent type (e.g., `VLLMAgent`) and want it to support embeddings:
-
-**Step 1:** Set the capability flag in `profile()`:
-
-```rust
-// src/agent/vllm.rs
-fn profile(&self) -> AgentProfile {
-    AgentProfile {
-        backend_type: "vllm".to_string(),
-        version: None,
-        privacy_zone: self.privacy_zone,
-        capabilities: AgentCapabilities {
-            embeddings: true,  // ← Enable embeddings
-            model_lifecycle: false,
-            token_counting: false,
-            resource_monitoring: false,
-        },
-        capability_tier: self.capability_tier,
-    }
-}
-```
-
-**Step 2:** Override `embeddings()` in your `InferenceAgent` implementation:
-
-```rust
-async fn embeddings(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, AgentError> {
-    // 1. Build the HTTP request for your backend's embedding endpoint
-    let url = format!("{}/v1/embeddings", self.base_url);
-    let body = serde_json::json!({
-        "model": "your-embedding-model",
-        "input": input,
-    });
-
-    // 2. Send the request
-    let response = self.client
-        .post(&url)
-        .json(&body)
-        .timeout(Duration::from_secs(60))
-        .send()
-        .await
-        .map_err(|e| AgentError::Network(e.to_string()))?;
-
-    // 3. Check status
-    if !response.status().is_success() {
-        return Err(AgentError::Upstream {
-            status: response.status().as_u16(),
-            message: response.text().await.unwrap_or_default(),
+    for text in &input {
+        let url = format!("{}/api/embed", self.base_url);
+        let body = serde_json::json!({
+            "model": model,        // ◄── forwarded from client request
+            "input": text,         // ◄── one input at a time
         });
-    }
 
-    // 4. Parse the response into Vec<Vec<f32>>
-    //    Adapt this to your backend's response format
-    let body: serde_json::Value = response.json().await
-        .map_err(|e| AgentError::InvalidResponse(e.to_string()))?;
+        let response = self.client
+            .post(&url)
+            .json(&body)
+            .timeout(Duration::from_secs(60))
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    AgentError::Timeout(60000)
+                } else {
+                    AgentError::Network(e.to_string())
+                }
+            })?;
 
-    let data = body["data"].as_array()
-        .ok_or_else(|| AgentError::InvalidResponse("Missing data".into()))?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let error_body = response.text().await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(AgentError::Upstream { status, message: error_body });
+        }
 
-    let results = data.iter().map(|item| {
-        item["embedding"].as_array()
-            .unwrap_or(&vec![])
-            .iter()
+        let body: serde_json::Value = response.json().await.map_err(|e| {
+            AgentError::InvalidResponse(format!(
+                "Failed to parse Ollama embed response: {}", e
+            ))
+        })?;
+
+        // Ollama returns { "embeddings": [[...]] }
+        let embeddings = body["embeddings"]
+            .as_array()
+            .and_then(|arr| arr.first())
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                AgentError::InvalidResponse(
+                    "Missing embeddings array in Ollama response".to_string(),
+                )
+            })?;
+
+        let vector: Vec<f32> = embeddings.iter()
             .filter_map(|v| v.as_f64().map(|f| f as f32))
-            .collect()
-    }).collect();
+            .collect();
+
+        results.push(vector);
+    }
 
     Ok(results)
 }
 ```
 
-**Step 3:** Add tests. At minimum:
+Key differences from the OpenAI implementation:
+
+| Aspect | OpenAI | Ollama |
+|--------|--------|--------|
+| Endpoint | `/v1/embeddings` | `/api/embed` |
+| Batch support | Native (all inputs in one request) | Per-input iteration (N requests for N inputs) |
+| Response format | `{ "data": [{"embedding": [...]}] }` | `{ "embeddings": [[...]] }` |
+| Authentication | Bearer token | None (local backend) |
+| Response navigation | `data[i].embedding` | `embeddings[0]` (first array element) |
+
+The per-input iteration is a trade-off:
+- **Pro**: Works with Ollama's native API without modifications
+- **Con**: N HTTP requests for N inputs (higher latency for large batches)
+- **Future**: If Ollama adds batch support, only this method needs updating — the handler stays unchanged
+
+---
+
+## File 5: api/headers.rs — The Return Label
+
+**Purpose**: Stamps every response with routing metadata — which backend handled the request, why it was chosen, and what privacy zone it belongs to.  
+**Lines**: 208  |  **Tests**: 2  |  **Status**: EXISTING (used by F17)
+
+### Why Does This Exist?
+
+Nexus never modifies the JSON response body (Constitution Principle III — OpenAI compatibility). All routing metadata goes into HTTP headers with the `X-Nexus-*` prefix. This is the "return label" — when a translated document comes back, the label tells you which translator handled it, without opening the envelope.
+
+### The Implementation
+
+The embeddings handler constructs and injects these headers after building the response:
 
 ```rust
-#[tokio::test]
-async fn test_embeddings_success() {
-    let mut server = Server::new_async().await;
-    let mock = server
-        .mock("POST", "/v1/embeddings")
-        .with_status(200)
-        .with_body(r#"{"data":[{"embedding":[0.1,0.2]}]}"#)
-        .create_async()
-        .await;
+// src/api/embeddings.rs (lines 177–187)
 
-    let agent = test_agent(server.url());
-    let result = agent.embeddings(vec!["hello".into()]).await.unwrap();
+let privacy_zone = agent.profile().privacy_zone;
+let nexus_headers = NexusTransparentHeaders::new(
+    backend.id.clone(),            // X-Nexus-Backend: "ollama-local"
+    backend.backend_type,          // X-Nexus-Backend-Type: "local" or "cloud"
+    RouteReason::CapabilityMatch,  // X-Nexus-Route-Reason: "capability-match"
+    privacy_zone,                  // X-Nexus-Privacy-Zone: "restricted" or "open"
+    routing_result.cost_estimated, // X-Nexus-Cost-Estimated: "0.0042" (cloud only)
+);
+nexus_headers.inject_into_response(&mut resp);
+```
 
-    mock.assert_async().await;
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0], vec![0.1, 0.2]);
+The `inject_into_response` method (in `headers.rs`, line 120) inserts all five headers into the response. Backend type is classified as `"local"` or `"cloud"` based on the `BackendType` enum — Ollama, vLLM, LlamaCpp, Exo, LMStudio, and Generic are `"local"`; OpenAI, Anthropic, and Google are `"cloud"`.
+
+Example response headers:
+
+```http
+HTTP/1.1 200 OK
+X-Nexus-Backend: openai-prod
+X-Nexus-Backend-Type: cloud
+X-Nexus-Route-Reason: capability-match
+X-Nexus-Privacy-Zone: open
+X-Nexus-Cost-Estimated: 0.0001
+Content-Type: application/json
+
+{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2,...],...}],...}
+```
+
+---
+
+## Understanding the Tests
+
+### Test Helpers
+
+The integration tests use a shared `common` module that provides `make_app_with_mock()` — a helper that creates a fully wired Axum app backed by a `wiremock::MockServer`:
+
+```rust
+// tests/embeddings_test.rs
+use common::make_app_with_mock;
+
+let mock_server = wiremock::MockServer::start().await;
+let (mut app, _registry) = make_app_with_mock(&mock_server).await;
+```
+
+This gives each test a clean app instance with a mock backend, so tests can control exactly what the "backend" returns.
+
+### Test Organization
+
+| Module | File | Test Count | What It Covers |
+|--------|------|------------|----------------|
+| `api::embeddings::tests` | `src/api/embeddings.rs` | 8 | Serialization/deserialization of all embedding types |
+| Integration tests | `tests/embeddings_test.rs` | 5 | Full HTTP stack with mock backends |
+
+### Testing Patterns
+
+**Pattern 1: Serialization Round-Trip**
+
+Many unit tests verify that types serialize and deserialize correctly — critical for OpenAI compatibility:
+
+```rust
+#[test]
+fn embedding_response_roundtrip() {
+    let response = EmbeddingResponse {
+        object: "list".to_string(),
+        data: vec![EmbeddingObject {
+            object: "embedding".to_string(),
+            embedding: vec![1.0, 2.0],
+            index: 0,
+        }],
+        model: "test-model".to_string(),
+        usage: EmbeddingUsage { prompt_tokens: 5, total_tokens: 5 },
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    let deserialized: EmbeddingResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.object, "list");
+    assert_eq!(deserialized.data[0].embedding, vec![1.0, 2.0]);
+    // ◄── Serialize → deserialize → same values: no data loss
 }
 ```
 
-**That's it.** The handler in `src/api/embeddings.rs` doesn't need any changes — it calls `agent.embeddings()` through the trait, so your new agent is automatically supported.
+This pattern ensures that every field survives the JSON round-trip — if serde skips a field or changes a type, this test catches it.
+
+**Pattern 2: Route Existence Verification**
+
+Integration tests verify the endpoint exists and responds with appropriate status codes, without needing a fully functional backend:
+
+```rust
+#[tokio::test]
+async fn embeddings_route_exists() {
+    let mock_server = wiremock::MockServer::start().await;
+    let (mut app, _registry) = make_app_with_mock(&mock_server).await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/embeddings")
+        .header("content-type", "application/json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.call(request).await.unwrap();
+
+    // Route exists — should not be 404 or 405
+    assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    // ◄── Verifies the route is wired up, regardless of handler outcome
+}
+```
+
+**Pattern 3: Negative Testing**
+
+Each error path gets its own test, verifying the handler returns the right HTTP status:
+
+```rust
+#[tokio::test]
+async fn embeddings_model_not_found_returns_error() {
+    let mock_server = wiremock::MockServer::start().await;
+    let (mut app, _registry) = make_app_with_mock(&mock_server).await;
+
+    let body = serde_json::json!({
+        "model": "nonexistent-model",
+        "input": "hello"
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/embeddings")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let response = app.call(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    // ◄── Unknown model → 404, not 500 or 502
+}
+```
+
+---
+
+## Key Rust Concepts
+
+### 1. `#[serde(untagged)]` for Flexible Input
+
+```rust
+#[derive(Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    Single(String),
+    Batch(Vec<String>),
+}
+```
+
+`#[serde(untagged)]` tells serde to try deserializing each variant in order without expecting a type tag. For `"input": "hello"` it tries `Single(String)` first — success. For `"input": ["hello", "world"]` it tries `Single` (fails), then `Batch(Vec<String>)` — success. This mirrors how OpenAI's API accepts both formats.
+
+### 2. `#[serde(skip_serializing_if)]` for Optional Fields
+
+```rust
+pub struct EmbeddingRequest {
+    pub model: String,
+    pub input: EmbeddingInput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding_format: Option<String>,
+}
+```
+
+When `encoding_format` is `None`, serde omits the field entirely from the JSON output instead of writing `"encoding_format": null`. This keeps the serialized JSON clean and matches what OpenAI clients expect.
+
+### 3. `Arc<AppState>` for Shared State
+
+```rust
+pub async fn handle(
+    State(state): State<Arc<AppState>>,
+    // ...
+```
+
+Axum extracts the shared application state via the `State` extractor. `Arc` (Atomic Reference Counting) lets multiple handler tasks share the same state without copying it. The registry, router, and HTTP client inside `AppState` are all thread-safe, so concurrent embedding requests don't conflict.
+
+### 4. `filter_map()` for Lossy Conversions
+
+```rust
+let vector: Vec<f32> = embedding.iter()
+    .filter_map(|v| v.as_f64().map(|f| f as f32))
+    .collect();
+```
+
+JSON numbers are parsed as `f64`. We need `f32` vectors (standard for embeddings). `filter_map()` combines filtering and mapping: `as_f64()` returns `None` for non-numeric values, which `filter_map()` silently skips. The `f64 as f32` cast loses precision but is acceptable — embedding vectors don't need 64-bit precision.
+
+### 5. Error Mapping with `map_err()`
+
+```rust
+let vectors = agent.embeddings(&request.model, input_texts).await
+    .map_err(|e| {
+        let _ = state.registry.decrement_pending(&backend.id);
+        ApiError::from_agent_error(e)
+    })?;
+```
+
+`map_err()` transforms the error type while also performing cleanup. Here, if the embedding call fails, we decrement the pending counter *before* converting the `AgentError` into an `ApiError`. The `?` operator then propagates the mapped error. This pattern ensures cleanup runs on both success and failure paths.
+
+---
+
+## Common Patterns in This Codebase
+
+### 1. The NII Agent Pattern
+
+Every backend interaction goes through the `InferenceAgent` trait. The handler never needs to know which backend type it's talking to:
+
+```rust
+// Handler doesn't care if this is OpenAI or Ollama
+let agent = state.registry.get_agent(&backend.id)?;
+let vectors = agent.embeddings(&request.model, input_texts).await?;
+```
+
+Adding a new backend that supports embeddings requires only two changes:
+1. Set `capabilities.embeddings: true` in `profile()`
+2. Override `embeddings()` with backend-specific HTTP logic
+
+The handler, router, and all other infrastructure work automatically.
+
+### 2. The Validate → Route → Gate → Delegate Pattern
+
+The embeddings handler follows the same pattern as chat completions:
+
+```
+Validate input format
+  │
+  ▼
+Route via Router::select_backend()
+  │
+  ▼
+Gate via capabilities check
+  │
+  ▼
+Delegate via agent.embeddings()
+  │
+  ▼
+Assemble response + headers
+```
+
+This separation means validation logic doesn't know about routing, routing doesn't know about agents, and agents don't know about HTTP response formatting. Each stage is independently testable and replaceable.
+
+### 3. The Transparent Headers Pattern
+
+Every response — chat completions, embeddings, models list — gets X-Nexus-* headers injected. The pattern is always the same:
+
+```rust
+let nexus_headers = NexusTransparentHeaders::new(
+    backend.id.clone(),
+    backend.backend_type,
+    RouteReason::CapabilityMatch,
+    privacy_zone,
+    routing_result.cost_estimated,
+);
+nexus_headers.inject_into_response(&mut resp);
+```
+
+This single injection point ensures consistency across all endpoints. The JSON body is never modified — only headers are added.
+
+### 4. The Pending Counter Pattern
+
+Load-aware routing needs to know how many requests each backend is currently processing:
+
+```rust
+let _ = state.registry.increment_pending(&backend.id);   // before call
+
+let result = agent.embeddings(&request.model, input_texts).await
+    .map_err(|e| {
+        let _ = state.registry.decrement_pending(&backend.id);  // on error
+        ApiError::from_agent_error(e)
+    })?;
+
+let _ = state.registry.decrement_pending(&backend.id);   // on success
+```
+
+The counter is decremented on both success and error paths. The `let _ =` pattern acknowledges that the `Result` is intentionally ignored — if pending tracking fails, the request should still proceed.
+
+---
+
+## Next Steps
+
+After understanding F17, here's what to explore next:
+
+1. **F15: Speculative Router** — The `RequestRequirements` struct and capability filtering that F17 reuses for routing (see `specs/018-speculative-router/walkthrough.md`)
+2. **F12: Transparent Protocol** — The full `NexusTransparentHeaders` system that F17 uses to inject routing metadata (see `src/api/headers.rs`)
+3. **Adding a new agent**: Try adding embeddings support to `GenericOpenAIAgent` — set the capability flag and override `embeddings()` (see pattern in File 3)
+
+### Questions to Investigate
+
+- What happens if a client sends `"encoding_format": "base64"` instead of `"float"`? (Hint: the `encoding_format` field is accepted but not used by the handler — it's forwarded to the agent)
+- Why does the handler decrement pending in *both* the error closure and after success? (Hint: the `?` operator would skip the post-success decrement on error)
+- How would you add dimension reduction (e.g., OpenAI's `dimensions` parameter)? (Hint: add it to `EmbeddingRequest`, forward it in the agent's request body, no handler logic changes needed)

--- a/specs/021-request-queuing/README.md
+++ b/specs/021-request-queuing/README.md
@@ -31,7 +31,7 @@ This directory contains the complete retrospective documentation for the Request
 
 | Source File | Purpose | Lines |
 |-------------|---------|-------|
-| `src/queue/mod.rs` | Core queue implementation | 595 |
+| `src/queue/mod.rs` | Core queue implementation | 632 |
 | `src/config/queue.rs` | Configuration structs | 59 |
 | `tests/queue_test.rs` | Integration tests | ~100 |
 

--- a/specs/021-request-queuing/checklists/requirements.md
+++ b/specs/021-request-queuing/checklists/requirements.md
@@ -62,7 +62,7 @@
 ### Retrospective Context
 
 This specification was created **after** the feature was fully implemented. All requirements, user scenarios, and success criteria were derived from the existing implementation in:
-- `src/queue/mod.rs` (595 lines, 14 unit tests)
+- `src/queue/mod.rs` (632 lines, 14 unit tests)
 - `src/config/queue.rs` (58 lines)
 - `src/api/completions.rs` (queue integration at lines 409-450)
 - `tests/queue_test.rs` (169 lines, 2 integration tests)

--- a/specs/021-request-queuing/plan.md
+++ b/specs/021-request-queuing/plan.md
@@ -159,7 +159,7 @@ All research questions resolved:
 
 **Status**: ✅ Implemented  
 **Source Files**:
-- `src/queue/mod.rs` (595 lines) - Core queue implementation
+- `src/queue/mod.rs` (632 lines) - Core queue implementation
 - `src/config/queue.rs` (59 lines) - Configuration
 - `src/api/completions.rs` - Integration (enqueue on RoutingError::Queue)
 - `tests/queue_test.rs` - Integration tests

--- a/specs/021-request-queuing/spec.md
+++ b/specs/021-request-queuing/spec.md
@@ -272,7 +272,7 @@ The `Retry-After` header indicates the suggested wait time before retrying.
 
 ### Key Files (for reference)
 
-- `src/queue/mod.rs` (595 lines): Core queue implementation with 14 unit tests
+- `src/queue/mod.rs` (632 lines): Core queue implementation with 14 unit tests
 - `src/config/queue.rs` (58 lines): Configuration structure
 - `src/routing/reconciler/decision.rs`: RoutingDecision::Queue variant
 - `src/api/completions.rs` (lines 409-450): API integration and priority parsing

--- a/specs/021-request-queuing/tasks.md
+++ b/specs/021-request-queuing/tasks.md
@@ -186,7 +186,7 @@
 ### Files Created/Modified
 
 **Created**:
-- `src/queue/mod.rs` (595 lines) - Main queue implementation + 14 unit tests
+- `src/queue/mod.rs` (632 lines) - Main queue implementation + 14 unit tests
 - `src/config/queue.rs` (58 lines) - Configuration structs
 - `tests/queue_test.rs` (169 lines) - 2 integration tests
 
@@ -250,7 +250,7 @@ max_wait_seconds = 30
 ### Total Implementation
 
 - **Total Tasks**: 47 tasks
-- **Lines of Code**: 822 lines (595 queue + 58 config + 169 tests)
+- **Lines of Code**: 859 lines (632 queue + 58 config + 169 tests)
 - **Test Count**: 16 tests (14 unit + 2 integration)
 - **Files Created**: 3 new files
 - **Files Modified**: 4 existing files

--- a/specs/021-request-queuing/walkthrough.md
+++ b/specs/021-request-queuing/walkthrough.md
@@ -1,202 +1,521 @@
 # F18: Request Queuing & Prioritization — Code Walkthrough
 
-> A junior-developer-friendly guide to how request queuing works in Nexus.
+**Feature**: Request Queuing & Prioritization (F18)  
+**Audience**: Junior developers joining the project  
+**Last Updated**: 2025-02-17
 
-## 1. Architecture Overview
+---
 
-When all backends are at capacity, Nexus queues incoming requests instead of immediately returning 503. The queue is a bounded, dual-priority FIFO backed by two tokio `mpsc` channels (one for high-priority, one for normal). A background drain loop polls every 50ms, re-runs routing for dequeued requests, and sends responses back through oneshot channels.
+## Table of Contents
+
+1. [The Big Picture](#the-big-picture)
+2. [File Structure](#file-structure)
+3. [File 1: queue/mod.rs — The Waiting Room](#file-1-queuemodrs--the-waiting-room)
+4. [File 2: config/queue.rs — The Admission Policy](#file-2-configqueuers--the-admission-policy)
+5. [File 3: routing/reconciler/decision.rs — The Triage Tag](#file-3-routingreconcilerdecisionrs--the-triage-tag)
+6. [File 4: api/completions.rs — The Intake Desk](#file-4-apicompletionsrs--the-intake-desk)
+7. [File 5: cli/serve.rs — The Hospital Opening & Closing](#file-5-cliservers--the-hospital-opening--closing)
+8. [Understanding the Tests](#understanding-the-tests)
+9. [Key Rust Concepts](#key-rust-concepts)
+10. [Common Patterns in This Codebase](#common-patterns-in-this-codebase)
+11. [Next Steps](#next-steps)
+
+---
+
+## The Big Picture
+
+Imagine Nexus is a **hospital emergency room**. Patients (requests) arrive at the front desk. Doctors (backends) treat them. Normally there are enough doctors for everyone, and patients go straight to treatment. But during a flu outbreak (burst traffic), every doctor is busy. Without a waiting room, the hospital would turn people away at the door — "come back later."
+
+That's what F18 adds: a **waiting room** for requests. When all backends are saturated, instead of immediately returning a 503 ("go away"), Nexus seats the request in a bounded waiting room with two sections — an **urgent care lane** (high priority) and a **general waiting area** (normal priority). A **triage nurse** (the drain loop) checks every 50ms whether a doctor has become available, and sends the next patient in.
+
+### What Problem Does This Solve?
+
+Without F18, a momentary spike — say 20 requests hitting 5 busy backends simultaneously — would cause 15 immediate 503 failures. But backends finish requests constantly. If we just wait 200ms, three backends might free up. F18 smooths over these burst gaps, turning transient overload into a brief wait instead of a hard failure.
+
+F18 does **not** solve sustained overload. If backends are permanently saturated, requests will eventually time out in the queue and get a 503 with a `Retry-After` header. The queue is a **shock absorber**, not infinite capacity.
+
+### How F18 Fits Into Nexus
 
 ```
-Client  ──POST /v1/chat/completions──▶  Handler  ──Router──▶  RoutingError::Queue
-                                       (completions.rs)              │
-                                             │                       ▼
-                                             │◀── oneshot ── RequestQueue (dual mpsc)
-                                             │                       ▲
-                                             │              queue_drain_loop (50ms poll)
-                                             │                       │
-                                             ▼              re-runs select_backend()
-                                        Response to client           │
-                                                            Agent ──▶ Backend
+┌──────────────────────────────────────────────────────────────────────────┐
+│                              Nexus                                      │
+│                                                                         │
+│  Client Request                                                         │
+│    │  POST /v1/chat/completions                                         │
+│    │  X-Nexus-Priority: high                                            │
+│    ▼                                                                    │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ① Handler (api/completions.rs)                                 │    │
+│  │     Calls Router::select_backend()                              │    │
+│  │     Router returns RoutingError::Queue                          │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ② Intake Desk (api/completions.rs)                ◄── F18     │    │
+│  │     • Extract priority from X-Nexus-Priority header             │    │
+│  │     • Create oneshot channel for response                       │    │
+│  │     • queue.enqueue(request) — CAS loop + try_send              │    │
+│  │     • Await oneshot (with tokio::time::timeout)                 │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ③ Waiting Room (queue/mod.rs)                     ◄── F18     │    │
+│  │                                                                 │    │
+│  │     ┌────────────────────┐  ┌──────────────────────┐           │    │
+│  │     │  HIGH-PRIORITY     │  │  NORMAL-PRIORITY     │           │    │
+│  │     │  mpsc channel      │  │  mpsc channel        │           │    │
+│  │     │  (urgent care)     │  │  (general waiting)   │           │    │
+│  │     └────────┬───────────┘  └──────────┬───────────┘           │    │
+│  │              │                         │                       │    │
+│  │              ▼                         ▼                       │    │
+│  │     AtomicUsize depth (total across both channels)             │    │
+│  └──┼──────────────────────────────────────────────────────────────┘    │
+│     │                                                                   │
+│     ▼                                                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐    │
+│  │  ④ Triage Nurse — queue_drain_loop (50ms poll)     ◄── F18     │    │
+│  │     • Dequeue: high channel first, then normal                  │    │
+│  │     • Timeout check: elapsed > max_wait → 503 + Retry-After    │    │
+│  │     • Re-run select_backend() for dequeued request              │    │
+│  │     • Success → forward to agent → send response via oneshot    │    │
+│  │     • No capacity → re-enqueue (preserving original timestamp)  │    │
+│  │     • Shutdown → drain all remaining with 503                   │    │
+│  └─────────────────────────────────────────────────────────────────┘    │
+│                                                                         │
+│  Data Flow: RoutingError::Queue → extract_priority(headers)            │
+│             → RequestQueue.enqueue() (CAS loop)                        │
+│             → queue_drain_loop (50ms poll)                              │
+│             → select_backend() retry → agent.chat_completion()         │
+│             → oneshot response → client                                │
+└──────────────────────────────────────────────────────────────────────────┘
 ```
 
-**Key architectural concepts:**
+### Key Design Decisions
 
-- **Dual-priority FIFO:** Two separate `mpsc` channels (high + normal). High-priority channel is always drained first. Within each channel, ordering is FIFO.
-- **Lock-free depth tracking:** An `AtomicUsize` tracks total depth across both channels — no mutex needed for the critical enqueue path.
-- **Oneshot response channel:** Each queued request carries a `oneshot::Sender`. The handler `await`s the corresponding `Receiver`. When the drain loop processes the request, it sends the response through the oneshot, unblocking the handler.
-- **Graceful shutdown:** The drain loop listens on a `CancellationToken`. On shutdown, it drains all remaining requests with 503 responses.
+| Decision | Why |
+|----------|-----|
+| Two `mpsc` channels instead of a `BinaryHeap` | Lock-free `try_send()` on enqueue; no custom comparator or heap rebalancing. Priority is structural (drain high first), not per-element |
+| `AtomicUsize` for depth, not `Mutex<usize>` | The enqueue path is latency-sensitive. Atomics avoid lock contention entirely. CAS loop prevents TOCTOU race |
+| CAS loop in `enqueue()` (not `load`+`fetch_add`) | A simple `load(); check; fetch_add()` has a TOCTOU race under concurrency — two threads could both see `depth=99`, both increment to 101, exceeding `max_size=100`. The `compare_exchange` loop eliminates this |
+| 50ms poll interval | Balances latency (acceptable for inference taking seconds) against CPU (~20 wakeups/sec). Not configurable yet — hardcoded for simplicity |
+| Re-enqueue on routing failure | Capacity may free up 50ms later. Preserves original `enqueued_at` so the timeout deadline doesn't reset |
+| Don't queue streaming requests | SSE connections must begin immediately. Holding the connection open with no output breaks client expectations |
+| `Retry-After` header on timeout | HTTP/1.1 semantics for 503. Tells well-behaved clients exactly when to retry, preventing thundering-herd retries |
+| Dual timeout (handler + drain) | Both sides check expiry independently — the handler via `tokio::time::timeout` on the oneshot, the drain loop via `enqueued_at.elapsed()`. A request can time out on either side |
 
-## 2. Request Flow
+---
 
-Here's what happens step-by-step when all backends are saturated:
+## File Structure
 
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│  1. Handler calls Router::select_backend()                          │
-│  2. Reconciler pipeline returns RoutingDecision::Queue              │
-│  3. Router converts to RoutingError::Queue { reason, est_wait_ms } │
-│  4. Handler catches RoutingError::Queue in match arm                │
-│  5. Extract priority from X-Nexus-Priority header (default: Normal) │
-│  6. Create QueuedRequest with oneshot::channel()                    │
-│  7. queue.enqueue(queued) — atomic depth check + try_send           │
-│  8. Handler awaits oneshot Receiver (with tokio::time::timeout)     │
-│  ─── meanwhile, in the background ───                               │
-│  9. queue_drain_loop polls every 50ms                               │
-│ 10. try_dequeue() checks high channel first, then normal            │
-│ 11. Check timeout: if elapsed > max_wait → 503 + Retry-After       │
-│ 12. Re-run select_backend() for the dequeued request                │
-│ 13. If routed: forward to agent, send response via oneshot          │
-│ 14. If still no capacity: re-enqueue (preserving original timestamp)│
-│ 15. Handler receives response through oneshot, returns to client    │
-└──────────────────────────────────────────────────────────────────────┘
+src/
+├── queue/
+│   └── mod.rs                       ← F18: RequestQueue, drain loop, all types (632 lines, 14 tests)
+├── config/
+│   └── queue.rs                     ← F18: QueueConfig struct (58 lines, 0 tests)
+├── routing/
+│   └── reconciler/
+│       └── decision.rs              ← F18: RoutingDecision::Queue variant (42 lines, 0 tests)
+├── api/
+│   └── completions.rs               ← F18: Queue integration in handler (lines 409–472)
+├── cli/
+│   └── serve.rs                     ← F18: Queue startup & shutdown (lines 224–333)
+
+tests/
+└── queue_test.rs                    ← F18: Integration tests (169 lines, 2 tests)
 ```
 
-### Error cases
+**F18 Contribution**: 1 new file (`queue/mod.rs`), 1 new config file (`config/queue.rs`), 1 new variant (`RoutingDecision::Queue`), 2 modified files (`completions.rs`, `serve.rs`), 1 integration test file. ~900 lines added, 14 unit tests, 2 integration tests.
 
-| Scenario | What happens | HTTP Status |
-|----------|-------------|-------------|
-| Queue disabled (`enabled=false` or `max_size=0`) | Immediate rejection | 503 |
-| Queue full (depth ≥ `max_size`) | Immediate rejection: "queue is full" | 503 |
-| Request times out in queue | 503 with `Retry-After` header | 503 |
-| Shutdown while requests queued | All drained with 503 | 503 |
-| Streaming request (`stream: true`) | Queuing skipped, immediate 503 | 503 |
+---
 
-## 3. Key Files
+## File 1: queue/mod.rs — The Waiting Room
 
-### `src/queue/mod.rs` — Core Queue (595 lines)
+**Purpose**: The core waiting room — data structures, enqueue/dequeue logic, the background drain loop, and all unit tests.  
+**Lines**: 632  |  **Tests**: 14  |  **Status**: NEW
 
-This is the heart of the feature. It defines the queue data structure, the drain loop, and all unit tests.
+### Why Does This Exist?
 
-**Types:**
+When `Router::select_backend()` returns `RoutingError::Queue`, the request needs somewhere to wait. This file provides the bounded, dual-priority queue and the background loop that periodically retries routing for waiting requests. Think of it as the hospital's waiting room combined with the triage nurse who keeps checking if a doctor is free.
+
+### The Types (Priority, QueuedRequest, QueueError)
 
 ```rust
-/// Two priority levels, parsed from X-Nexus-Priority header
+// src/queue/mod.rs, lines 16–68
+
+/// Priority level for queued requests
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Priority {
     High,
     Normal,
 }
 
+impl Priority {
+    /// Parse priority from header value. Invalid values default to Normal.
+    pub fn from_header(value: &str) -> Self {
+        match value.trim().to_lowercase().as_str() {
+            "high" => Priority::High,
+            _ => Priority::Normal,
+        }
+    }
+}
+```
+
+Only two levels — `High` and `Normal`. In the hospital metaphor, this is like having an "urgent care" lane and a "general" lane. The parser is deliberately permissive: only the exact string `"high"` (case-insensitive, trimmed) gets priority treatment. Everything else — `"normal"`, `"urgent"`, `"low"`, `""`, garbage — maps to `Normal`. This is a safe default: no one accidentally gets priority.
+
+```rust
+// src/queue/mod.rs, lines 33–53
+
 /// A request waiting in the queue
 pub struct QueuedRequest {
     pub intent: RoutingIntent,           // Routing metadata from reconciler
     pub request: ChatCompletionRequest,  // Original request body
-    pub response_tx: oneshot::Sender<QueueResponse>,  // Response channel
-    pub enqueued_at: Instant,            // For timeout detection
-    pub priority: Priority,
-}
-
-/// Errors from queue operations
-pub enum QueueError {
-    Full { max_size: u32 },  // Queue at capacity
-    Disabled,                // Queuing is off
+    pub response_tx: oneshot::Sender<QueueResponse>,  // Response channel back to handler
+    pub enqueued_at: Instant,            // When the patient sat down (for timeout)
+    pub priority: Priority,              // Urgent care or general waiting?
 }
 ```
 
-**`RequestQueue` — the dual-channel bounded queue:**
+Each waiting patient carries everything needed to resume treatment later. The `response_tx` is the critical piece — it's a one-shot channel that connects back to the HTTP handler waiting for a response. When the drain loop finishes processing, it sends the result through this channel, and the handler unblocks and returns the response to the client.
 
 ```rust
+// src/queue/mod.rs, lines 58–68
+
+#[derive(Debug, Error)]
+pub enum QueueError {
+    #[error("Queue is full ({max_size} requests)")]
+    Full { max_size: u32 },
+
+    #[error("Request queuing is disabled")]
+    Disabled,
+}
+```
+
+Two reasons a request can't enter the waiting room: it's full (all chairs taken), or the waiting room is closed. Both result in an immediate 503 to the client.
+
+### The Queue Structure (RequestQueue)
+
+```rust
+// src/queue/mod.rs, lines 70–81
+
 pub struct RequestQueue {
     high_tx: mpsc::Sender<QueuedRequest>,
     high_rx: tokio::sync::Mutex<mpsc::Receiver<QueuedRequest>>,
     normal_tx: mpsc::Sender<QueuedRequest>,
     normal_rx: tokio::sync::Mutex<mpsc::Receiver<QueuedRequest>>,
-    depth: Arc<AtomicUsize>,  // lock-free total depth
+    depth: Arc<AtomicUsize>,
     config: QueueConfig,
 }
 ```
 
-Both channels are created with capacity equal to `max_size`. The total depth is enforced atomically in `enqueue()` — the per-channel capacities are a safety net, not the primary bound.
+The waiting room has two physical sections — an urgent care lane (`high_tx`/`high_rx`) and a general area (`normal_tx`/`normal_rx`). Both use tokio's `mpsc` (multi-producer, single-consumer) channels.
 
-**`enqueue()` — the hot path:**
+Why `Mutex<Receiver>`? Because `mpsc::Receiver::try_recv()` takes `&mut self`, but `RequestQueue` is shared via `Arc`. The `Mutex` provides interior mutability. Since only the drain loop calls `try_dequeue()`, contention is zero in practice — the `Mutex` is a compile-time requirement, not a runtime bottleneck.
+
+Both channels are created with capacity equal to `max_size` (line 89). The **primary** bound is the atomic `depth` counter; the per-channel capacities are a safety net.
+
+### The Enqueue Method (CAS Loop)
+
+This is the most important method in the file — the "hot path" that every queued request flows through:
 
 ```rust
-pub fn enqueue(&self, request: QueuedRequest) -> Result<(), QueueError> {
-    if !self.config.is_enabled() { return Err(QueueError::Disabled); }
+// src/queue/mod.rs, lines 102–142
 
-    let current = self.depth.load(Ordering::SeqCst);
-    if current >= self.config.max_size as usize {
-        return Err(QueueError::Full { max_size: self.config.max_size });
+pub fn enqueue(&self, request: QueuedRequest) -> Result<(), QueueError> {
+    if !self.config.is_enabled() {
+        return Err(QueueError::Disabled);
     }
 
-    self.depth.fetch_add(1, Ordering::SeqCst);
-    // Route to correct channel by priority
+    // CAS loop to atomically check-and-increment depth, preventing TOCTOU race
+    loop {
+        let current = self.depth.load(Ordering::SeqCst);
+        if current >= self.config.max_size as usize {
+            return Err(QueueError::Full {
+                max_size: self.config.max_size,
+            });
+        }
+        if self
+            .depth
+            .compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            break;
+        }
+    }
+    metrics::gauge!("nexus_queue_depth").set(self.depth() as f64);
+
     let tx = match request.priority {
         Priority::High => &self.high_tx,
         Priority::Normal => &self.normal_tx,
     };
-    // try_send is non-blocking; rollback depth on failure
+
+    // try_send is non-blocking; if the channel is full, we already checked
+    // depth so this should succeed unless there's a race (acceptable).
     if tx.try_send(request).is_err() {
         self.depth.fetch_sub(1, Ordering::SeqCst);
-        return Err(QueueError::Full { max_size: self.config.max_size });
+        metrics::gauge!("nexus_queue_depth").set(self.depth() as f64);
+        return Err(QueueError::Full {
+            max_size: self.config.max_size,
+        });
     }
+
     Ok(())
 }
 ```
 
-Note: There's a small TOCTOU race between `depth.load()` and `fetch_add()` — this is acceptable because the per-channel capacity provides a hard backstop.
+Let's trace through this carefully, because the CAS (Compare-And-Swap) loop is the most subtle part of the entire feature:
 
-**`try_dequeue()` — priority ordering:**
+1. **Gate check** (line 104): If the waiting room is closed (`enabled=false` or `max_size=0`), reject immediately.
+
+2. **CAS loop** (lines 109–123): This is the critical section. We need to atomically check "is there room?" AND increment the counter. A naive approach would be:
+   ```rust
+   let current = depth.load();         // Thread A sees 99
+   if current >= max_size { return Err; }  // Thread A: 99 < 100, OK
+   depth.fetch_add(1);                 // Thread A increments to 100
+   // But Thread B also saw 99, also passed the check, and increments to 101!
+   ```
+   The `compare_exchange` solves this: it says "set depth to `current + 1`, but **only if** it's still `current`." If another thread snuck in and changed the value, `compare_exchange` fails and we retry the loop.
+
+3. **Metrics update** (line 124): After successfully reserving a slot, update the Prometheus gauge.
+
+4. **Channel send** (lines 126–139): Route to the correct channel by priority. `try_send()` is non-blocking — it either succeeds instantly or fails. If it fails (shouldn't happen given the depth check, but defensive), we roll back the depth counter.
+
+### The Dequeue Method
 
 ```rust
+// src/queue/mod.rs, lines 144–167
+
 pub async fn try_dequeue(&self) -> Option<QueuedRequest> {
     // Try high priority first
-    { let mut rx = self.high_rx.lock().await; /* try_recv */ }
+    {
+        let mut rx = self.high_rx.lock().await;
+        if let Ok(req) = rx.try_recv() {
+            self.depth.fetch_sub(1, Ordering::SeqCst);
+            metrics::gauge!("nexus_queue_depth").set(self.depth() as f64);
+            return Some(req);
+        }
+    }
+
     // Then normal priority
-    { let mut rx = self.normal_rx.lock().await; /* try_recv */ }
+    {
+        let mut rx = self.normal_rx.lock().await;
+        if let Ok(req) = rx.try_recv() {
+            self.depth.fetch_sub(1, Ordering::SeqCst);
+            metrics::gauge!("nexus_queue_depth").set(self.depth() as f64);
+            return Some(req);
+        }
+    }
+
     None
 }
 ```
 
-The `Mutex<Receiver>` is required because `mpsc::Receiver::try_recv()` takes `&mut self`. Since only the drain loop calls `try_dequeue()`, contention is zero in practice.
+The triage nurse always checks the urgent care lane first. The `{}` blocks are important — they scope the `Mutex` lock. Without them, we'd hold the high-priority lock while checking the normal-priority channel, which would block any concurrent `try_dequeue` (though in practice, only the drain loop calls this).
 
-**`queue_drain_loop()` — the background processor:**
-
-The drain loop runs as a `tokio::spawn` task. It polls every 50ms using `tokio::select!` with the cancellation token:
-
-1. **Dequeue** — tries all available requests per poll cycle (inner `while let`)
-2. **Timeout check** — if `enqueued_at.elapsed() > max_wait`, sends 503 + `Retry-After`
-3. **Re-route** — calls `state.router.select_backend()` with `TierEnforcementMode::Strict`
-4. **Success** — forwards to `process_queued_request()`, sends response via oneshot
-5. **No capacity** — re-enqueues with original `enqueued_at` (preserves timeout deadline)
-6. **Shutdown** — `drain_remaining()` sends 503 to all queued requests
-
-**`process_queued_request()` — forwarding to backend:**
+### The Drain Loop
 
 ```rust
-async fn process_queued_request(state, routing_result, request) -> QueueResponse {
-    let backend = &routing_result.backend;
-    state.registry.increment_pending(&backend.id);
+// src/queue/mod.rs, lines 185–279
 
-    let result = if let Some(agent) = state.registry.get_agent(&backend.id) {
-        agent.chat_completion(request, None).await
-    } else {
-        Err(ApiError::bad_gateway("Agent not found"))
-    };
+pub async fn queue_drain_loop(
+    queue: Arc<RequestQueue>,
+    state: Arc<crate::api::AppState>,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                drain_remaining(&queue).await;   // Send 503 to everyone still waiting
+                break;
+            }
+            _ = tokio::time::sleep(Duration::from_millis(50)) => {
+                while let Some(queued) = queue.try_dequeue().await {
+                    let max_wait = Duration::from_secs(queue.config().max_wait_seconds);
 
-    state.registry.decrement_pending(&backend.id);
-    // Convert to Response
+                    // Drain-side timeout: skip requests already expired before processing.
+                    // The handler also has its own timeout guard (tokio::time::timeout on
+                    // the oneshot rx), so a request may time out on either side.
+                    if queued.enqueued_at.elapsed() > max_wait {
+                        let _ = queued.response_tx.send(Ok(build_timeout_response(...)));
+                        continue;
+                    }
+
+                    // Re-run routing
+                    let result = state.router.select_backend(&requirements, Some(Strict));
+                    match result {
+                        Ok(routing_result) => {
+                            let response = process_queued_request(&state, &routing_result, &queued.request).await;
+                            let _ = queued.response_tx.send(response);
+                        }
+                        Err(_) => {
+                            // Still no capacity — re-enqueue with original timestamp
+                            if queued.enqueued_at.elapsed() < max_wait {
+                                let re_queued = QueuedRequest {
+                                    enqueued_at: queued.enqueued_at,  // ◄── preserve original!
+                                    ..
+                                };
+                                let _ = queue.enqueue(re_queued);
+                            } else {
+                                let _ = queued.response_tx.send(Ok(build_timeout_response(...)));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
-This mirrors the normal completion handler flow — increment pending, call agent, decrement pending.
+The drain loop is the triage nurse's routine. Every 50ms, she:
 
-### `src/config/queue.rs` — Configuration (58 lines)
+1. **Checks the waiting room** — dequeues all available requests (inner `while let` loop)
+2. **Checks the patient's wristband** — if they've been waiting longer than `max_wait_seconds`, send them home with a 503 and `Retry-After` header
+3. **Tries to find a doctor** — re-runs `select_backend()` with `TierEnforcementMode::Strict`
+4. **Doctor available?** — forward to the agent via `process_queued_request()`, send response through the oneshot channel
+5. **No doctor yet?** — put the patient back in the waiting room, keeping their original arrival timestamp so the timeout doesn't reset
+6. **Hospital closing?** — `CancellationToken` fires, `drain_remaining()` sends 503 to everyone
 
-Three fields with serde defaults:
+The **double timeout comment** (lines 211–213) is worth calling out: both the handler side (`tokio::time::timeout` on the oneshot receiver) and the drain side (`enqueued_at.elapsed()` check) independently enforce the timeout. A request can expire on either side — whichever fires first wins.
+
+### Key Tests
+
+The file contains 14 unit tests organized into three groups:
 
 ```rust
+// T021: Queue structure tests
+#[tokio::test]
+async fn fifo_ordering_normal_priority() {
+    // Enqueue 3 normal requests, verify they dequeue in FIFO order
+    let queue = RequestQueue::new(make_config(10, 30));
+    queue.enqueue(req1).unwrap();
+    queue.enqueue(req2).unwrap();
+    queue.enqueue(req3).unwrap();
+    let d1 = queue.try_dequeue().await.unwrap();
+    assert_eq!(d1.enqueued_at, t1);  // First in = first out
+}
+
+#[tokio::test]
+async fn priority_ordering_high_drains_first() {
+    // Enqueue: normal, high, normal → dequeue: high, normal, normal
+    let d1 = queue.try_dequeue().await.unwrap();
+    assert_eq!(d1.priority, Priority::High);  // ◄── High always first
+}
+
+#[tokio::test]
+async fn capacity_limits_reject_when_full() {
+    let queue = RequestQueue::new(make_config(2, 30));
+    queue.enqueue(req1).unwrap();  // depth=1
+    queue.enqueue(req2).unwrap();  // depth=2
+    let result = queue.enqueue(req3);
+    assert!(matches!(result, Err(QueueError::Full { max_size: 2 })));
+}
+```
+
+```rust
+// T028: Priority parsing tests
+#[test]
+fn priority_from_header_high() {
+    assert_eq!(Priority::from_header("high"), Priority::High);
+    assert_eq!(Priority::from_header("HIGH"), Priority::High);
+    assert_eq!(Priority::from_header(" High "), Priority::High);
+}
+
+#[test]
+fn priority_from_header_invalid_defaults_to_normal() {
+    assert_eq!(Priority::from_header(""), Priority::Normal);
+    assert_eq!(Priority::from_header("urgent"), Priority::Normal);
+    assert_eq!(Priority::from_header("low"), Priority::Normal);
+}
+```
+
+```rust
+// CAS loop correctness test (newest — validates the TOCTOU fix)
+#[tokio::test]
+async fn concurrent_enqueue_respects_max_size() {
+    let queue = Arc::new(RequestQueue::new(make_config(10, 30)));
+    let mut handles = vec![];
+
+    // Spawn 50 concurrent tasks trying to enqueue
+    for _ in 0..50 {
+        let q = Arc::clone(&queue);
+        handles.push(tokio::spawn(async move {
+            let (req, _rx) = make_queued(Priority::Normal);
+            q.enqueue(req)
+        }));
+    }
+
+    let results: Vec<_> = futures::future::join_all(handles).await;
+    let successes = results.iter().filter(|r| r.as_ref().unwrap().is_ok()).count();
+
+    assert_eq!(successes, 10, "Exactly max_size requests should succeed");
+    assert_eq!(queue.depth(), 10);
+}
+```
+
+This last test is the most important — it proves the CAS loop works under contention. 50 tasks race to enqueue into a queue with `max_size=10`. Without the CAS loop, more than 10 could slip through. With it, **exactly** 10 succeed.
+
+---
+
+## File 2: config/queue.rs — The Admission Policy
+
+**Purpose**: Configuration for the waiting room — how many chairs, how long patients can wait, and whether it's open at all.  
+**Lines**: 58  |  **Tests**: 0  |  **Status**: NEW
+
+### Why Does This Exist?
+
+Every hospital has an admission policy: maximum capacity, maximum wait time, whether the waiting room is open. This file encodes those policies as a TOML-deserializable struct with sensible defaults.
+
+### The Struct
+
+```rust
+// src/config/queue.rs, lines 18–39
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct QueueConfig {
-    pub enabled: bool,           // default: true
-    pub max_size: u32,           // default: 100
-    pub max_wait_seconds: u64,   // default: 30
+    /// Whether request queuing is enabled.
+    /// Default: true
+    pub enabled: bool,
+
+    /// Maximum number of queued requests.
+    /// Default: 100
+    /// When max_size is 0, queuing is disabled (equivalent to enabled=false).
+    pub max_size: u32,
+
+    /// Maximum wait time for queued requests in seconds.
+    /// Default: 30 seconds
+    pub max_wait_seconds: u64,
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_size: 100,
+            max_wait_seconds: 30,
+        }
+    }
 }
 ```
 
-`is_enabled()` returns `false` when either `enabled == false` or `max_size == 0`. This dual-check prevents a confusing state where queuing is "enabled" but has zero capacity.
+Three knobs, sensible defaults. The `#[serde(default)]` attribute means all fields are optional in the TOML file — any missing field gets the `Default` implementation value.
 
-**Configuration in `nexus.example.toml`:**
+The `is_enabled()` helper (line 55) catches a subtle edge case:
+
+```rust
+// src/config/queue.rs, lines 51–57
+
+pub fn is_enabled(&self) -> bool {
+    self.enabled && self.max_size > 0
+}
+```
+
+A waiting room that's "enabled" but has zero chairs is effectively closed. This dual-check prevents a confusing configuration where `enabled=true` but `max_size=0` — both must be satisfied.
+
+Configuration in `nexus.example.toml`:
 
 ```toml
 [queue]
@@ -205,215 +524,496 @@ max_size = 100
 max_wait_seconds = 30
 ```
 
-### `src/routing/reconciler/decision.rs` — RoutingDecision::Queue
+---
 
-The reconciler pipeline can produce three outcomes:
+## File 3: routing/reconciler/decision.rs — The Triage Tag
+
+**Purpose**: Defines `RoutingDecision::Queue` — the triage tag that says "this patient needs to wait."  
+**Lines**: 42  |  **Tests**: 0  |  **Status**: MODIFIED (Queue variant added)
+
+### Why Does This Exist?
+
+The reconciler pipeline (Privacy → Budget → Tier → Quality → Scheduler) produces a decision for every request. Before F18, there were only two outcomes: `Route` (send to a backend) and `Reject` (refuse with reasons). F18 adds a third: `Queue` — "we have backends that could serve this, but they're all busy right now."
+
+### The Queue Variant
 
 ```rust
+// src/routing/reconciler/decision.rs, lines 9–42
+
 pub enum RoutingDecision {
-    Route { agent_id, model, reason, cost_estimate },
-    Queue { reason, estimated_wait_ms, fallback_agent },  // ← triggers queuing
-    Reject { rejection_reasons },
+    /// Successful routing to an agent
+    Route {
+        agent_id: String,
+        model: String,
+        reason: String,
+        cost_estimate: CostEstimate,
+    },
+
+    /// Agent is busy, queue or wait required
+    Queue {
+        /// Reason for queueing
+        reason: String,
+        /// Estimated wait time in milliseconds
+        estimated_wait_ms: u64,
+        /// Fallback agent if available
+        fallback_agent: Option<String>,
+    },
+
+    /// No viable agents, request rejected
+    Reject {
+        rejection_reasons: Vec<RejectionReason>,
+    },
 }
 ```
 
-When the `SchedulerReconciler` determines all candidates are at capacity, it returns `Queue`. The `Router::select_backend()` method converts this to `RoutingError::Queue`, which the handler catches.
+The `Queue` variant carries context that helps downstream code make decisions:
 
-### `src/api/completions.rs` — Handler Integration (lines ~409-470)
+- **`reason`**: Human-readable explanation (e.g., "All backends at capacity")
+- **`estimated_wait_ms`**: How long the caller might wait — used for logging, not enforcement (the actual timeout comes from `QueueConfig.max_wait_seconds`)
+- **`fallback_agent`**: If there's a fallback backend that might handle the request — currently unused in the drain loop but available for future optimization
 
-The handler catches `RoutingError::Queue` and interacts with the queue:
+When the `SchedulerReconciler` scores all candidates and finds every backend is overloaded, it produces a `Queue` decision. The `Router::select_backend()` method converts this into a `RoutingError::Queue`, which the HTTP handler catches.
+
+---
+
+## File 4: api/completions.rs — The Intake Desk
+
+**Purpose**: The HTTP handler that catches `RoutingError::Queue`, creates a `QueuedRequest`, enqueues it, and waits for the response.  
+**Lines**: ~1100 total (F18 adds lines 409–472 and the `extract_priority` function at line 75)  
+**Status**: MODIFIED
+
+### Why Does This Exist?
+
+This is the front desk of the hospital. When a patient arrives and the triage tag says "wait," the intake desk handles the paperwork: extracts the priority from the patient's wristband (the `X-Nexus-Priority` header), creates the waiting room record, hands it to the queue, and then sits with the patient (awaits the oneshot channel) until the triage nurse sends them to a doctor.
+
+### Queue Integration
 
 ```rust
-crate::routing::RoutingError::Queue { reason, estimated_wait_ms } => {
+// src/api/completions.rs, lines 409–472
+
+crate::routing::RoutingError::Queue {
+    reason,
+    estimated_wait_ms,
+} => {
+    // T027: Enqueue if queue available
     if let Some(ref queue) = state.queue {
-        let priority = extract_priority(&headers);  // X-Nexus-Priority
+        let priority = extract_priority(&headers);
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let queued = QueuedRequest { intent, request, response_tx: tx, ... };
+        let intent = crate::routing::reconciler::intent::RoutingIntent::new(
+            request_id.clone(),
+            requested_model.clone(),
+            requested_model.clone(),
+            requirements.clone(),
+            vec![],
+        );
+        let queued = crate::queue::QueuedRequest {
+            intent,
+            request: request.clone(),
+            response_tx: tx,
+            enqueued_at: std::time::Instant::now(),
+            priority,
+        };
 
         match queue.enqueue(queued) {
             Ok(()) => {
-                // Wait for drain loop to process, with timeout
+                info!(
+                    reason = %reason,
+                    estimated_wait_ms,
+                    priority = ?priority,
+                    "Request enqueued"
+                );
+
+                let max_wait =
+                    std::time::Duration::from_secs(queue.config().max_wait_seconds);
                 match tokio::time::timeout(max_wait, rx).await {
-                    Ok(Ok(resp)) => return resp,
-                    _ => return Ok(build_timeout_response(...)),
+                    Ok(Ok(resp)) => {
+                        return resp;
+                    }
+                    _ => {
+                        return Ok(crate::queue::build_timeout_response(
+                            &queue.config().max_wait_seconds.to_string(),
+                        ));
+                    }
                 }
             }
-            Err(QueueError::Full { .. }) => { /* 503: queue full */ }
-            Err(QueueError::Disabled) => { /* 503: at capacity */ }
+            Err(crate::queue::QueueError::Full { .. }) => {
+                warn!("Queue full, rejecting request");
+                return Ok(ApiError::service_unavailable(
+                    "All backends at capacity and queue is full",
+                )
+                .into_response());
+            }
+            Err(crate::queue::QueueError::Disabled) => {
+                return Ok(ApiError::service_unavailable(
+                    "All backends at capacity",
+                )
+                .into_response());
+            }
         }
     } else {
-        // No queue configured — immediate 503
+        return Ok(ApiError::service_unavailable("All backends at capacity")
+            .into_response());
     }
 }
 ```
 
-**Priority extraction** (line 75):
+Let's trace the flow:
+
+1. **Queue available?** (line 414): `state.queue` is `Option<Arc<RequestQueue>>`. If `None`, there's no waiting room — immediate 503.
+
+2. **Create the patient record** (lines 415–430): Bundle the priority, the original request, a oneshot sender, and the current timestamp into a `QueuedRequest`.
+
+3. **Try to enter** (line 432): Call `queue.enqueue()`. Three outcomes:
+   - **`Ok(())`**: Patient is seated. Now we wait.
+   - **`Err(Full)`**: Waiting room full. Immediate 503: "queue is full."
+   - **`Err(Disabled)`**: Waiting room closed. Immediate 503: "at capacity."
+
+4. **Wait for the doctor** (lines 441–452): `tokio::time::timeout(max_wait, rx).await` blocks the HTTP handler until either:
+   - The drain loop sends a response through the oneshot → return it to the client
+   - The timeout expires → return a 503 with `Retry-After` header
+
+This is the handler-side timeout. The drain loop also checks timeouts independently (dual timeout design).
+
+### Priority Extraction
 
 ```rust
-fn extract_priority(headers: &HeaderMap) -> Priority {
-    headers.get("x-nexus-priority")
+// src/api/completions.rs, lines 71–81
+
+/// Header name for request priority (T028)
+const PRIORITY_HEADER: &str = "x-nexus-priority";
+
+fn extract_priority(headers: &HeaderMap) -> crate::queue::Priority {
+    headers
+        .get(PRIORITY_HEADER)
         .and_then(|v| v.to_str().ok())
-        .map(Priority::from_header)
-        .unwrap_or(Priority::Normal)
+        .map(crate::queue::Priority::from_header)
+        .unwrap_or(crate::queue::Priority::Normal)
 }
 ```
 
-`Priority::from_header()` is case-insensitive — `"high"`, `"HIGH"`, `" High "` all map to `High`. Everything else defaults to `Normal`.
+Reading the patient's wristband. The `and_then` chain safely handles: header missing → `None` → `unwrap_or(Normal)`. Header present but invalid UTF-8 → `to_str()` returns `None` → defaults to `Normal`. Header present and valid → `Priority::from_header()` parses it (case-insensitive).
 
-**Streaming requests** are not queued (line ~875) — they get an immediate 503 because queuing doesn't make sense for SSE streams.
+Streaming requests (line 876) are **not** queued — they get an immediate 503 because SSE connections must begin transmitting immediately.
 
-### `src/cli/serve.rs` — Startup & Shutdown
+---
 
-**Queue creation** (line ~224):
+## File 5: cli/serve.rs — The Hospital Opening & Closing
+
+**Purpose**: Creates the queue at server startup, starts the drain loop as a background task, and shuts both down gracefully.  
+**Lines**: ~340 total (F18 adds lines 224–237 and 288–333)  
+**Status**: MODIFIED
+
+### Why Does This Exist?
+
+Someone has to unlock the waiting room doors in the morning and lock them at night. The `serve` command handles the full lifecycle: create the queue → inject it into `AppState` → enable queue-aware routing → spawn the drain loop → wait for shutdown → drain remaining → clean up.
+
+### Queue Startup and Shutdown
+
+**Step 1: Create the waiting room** (lines 224–237):
 
 ```rust
+// src/cli/serve.rs, lines 224–237
+
+// 4. Create request queue (if enabled) (T030)
 let queue = if config.queue.is_enabled() {
-    Some(Arc::new(RequestQueue::new(config.queue.clone())))
-} else { None };
+    tracing::info!(
+        max_size = config.queue.max_size,
+        max_wait_seconds = config.queue.max_wait_seconds,
+        "Request queuing enabled"
+    );
+    Some(Arc::new(crate::queue::RequestQueue::new(
+        config.queue.clone(),
+    )))
+} else {
+    tracing::debug!("Request queuing disabled");
+    None
+};
 ```
 
-The queue is passed into `AppState` and also used to enable queue-aware routing on the `Router`:
+If the config says the waiting room should be open, create it wrapped in `Arc` for shared ownership. Otherwise, `None` — no queue, no drain loop.
+
+**Step 2: Wire it into the API** (lines 160–168):
 
 ```rust
+// src/cli/serve.rs, lines 160–168
+
 app_state.queue = queue;
+// Enable queue-aware routing when queue is configured
 if config.queue.is_enabled() {
-    router.set_queue_enabled(true);
+    if let Some(router) = Arc::get_mut(&mut app_state.router) {
+        router.set_queue_enabled(true);
+    }
 }
 ```
 
-**Drain loop startup** (line ~288):
+Two things happen: the queue is stored in `AppState` (so the handler can access it), and the router is told that queuing is available (so it returns `RoutingError::Queue` instead of `RoutingError::NoBackend` when backends are saturated).
+
+**Step 3: Start the drain loop** (lines 288–299):
 
 ```rust
+// src/cli/serve.rs, lines 288–299
+
+// 4.8. Start queue drain loop (T030)
 let queue_handle = if let Some(ref q) = queue {
+    tracing::info!("Starting queue drain loop");
     let queue_clone = Arc::clone(q);
+    let state_clone = Arc::clone(&app_state);
     let queue_cancel = cancel_token.clone();
     Some(tokio::spawn(async move {
-        queue_drain_loop(queue_clone, state_clone, queue_cancel).await;
+        crate::queue::queue_drain_loop(queue_clone, state_clone, queue_cancel).await;
     }))
-} else { None };
+} else {
+    None
+};
 ```
 
-**Graceful shutdown** (line ~330):
+The drain loop runs as a `tokio::spawn` task — a long-lived background green thread. It receives clones of the `Arc`s it needs and a `CancellationToken` for shutdown signaling.
+
+**Step 4: Graceful shutdown** (lines 330–333):
 
 ```rust
+// src/cli/serve.rs, lines 330–333
+
 if let Some(handle) = queue_handle {
-    handle.await?;  // waits for drain_remaining() to finish
+    tracing::info!("Waiting for queue drain loop to stop");
+    handle.await?;
 }
 ```
 
-The `CancellationToken` triggers `drain_remaining()` inside the drain loop, which sends 503 to all in-flight requests before the task exits.
+When the server shuts down (Ctrl-C → `CancellationToken` fires), the drain loop's `tokio::select!` picks up the cancellation, calls `drain_remaining()` (which sends 503 to all waiting requests), and exits. The `handle.await?` ensures we don't exit before all patients have been notified.
 
-## 4. Design Decisions
+---
 
-### Why two mpsc channels instead of a priority queue?
+## Understanding the Tests
 
-A `BinaryHeap` or similar priority queue would require a `Mutex` for every enqueue/dequeue. Using two `mpsc` channels gives us:
+### Test Helpers
 
-- **Lock-free enqueue** — `try_send()` is non-blocking
-- **Natural priority** — always drain `high_rx` before `normal_rx`
-- **Bounded by construction** — tokio channels enforce capacity limits
-- **Simple implementation** — no custom comparator or heap rebalancing
-
-The trade-off is that within a priority level, we get FIFO (not arbitrary ordering), which is exactly what we want.
-
-### Why AtomicUsize for depth?
-
-The queue needs to enforce a total capacity across both channels. An `AtomicUsize` lets us check and update depth without holding a lock. The `SeqCst` ordering ensures visibility across the enqueue path and the drain loop.
-
-### Why re-enqueue on routing failure?
-
-When the drain loop dequeues a request but `select_backend()` still fails, the request goes back into the queue rather than being dropped. This is because capacity may free up on the next poll cycle (50ms later). The original `enqueued_at` timestamp is preserved so the timeout deadline doesn't reset.
-
-### Why 50ms poll interval?
-
-This balances latency against CPU usage. At 50ms:
-- Worst-case added latency: 50ms (acceptable for inference requests that take seconds)
-- CPU overhead: negligible (~20 wakeups/sec when idle)
-- Response time: requests are served within one poll cycle of capacity becoming available
-
-### Why not queue streaming requests?
-
-Streaming (`stream: true`) uses Server-Sent Events. The HTTP response must begin immediately to start the SSE connection. Queuing would mean holding the connection open with no output, which breaks SSE client expectations. Instead, streaming requests get an immediate 503.
-
-### Why Retry-After header?
-
-The `Retry-After` header (set to `max_wait_seconds`) tells well-behaved HTTP clients exactly how long to wait before retrying. This prevents thundering-herd retries and follows HTTP/1.1 semantics for 503 responses.
-
-## 5. Metrics
-
-The queue emits a single Prometheus gauge:
+All test modules use factory functions to create test fixtures. This keeps individual tests focused on what they're verifying, not on boilerplate setup:
 
 ```rust
-metrics::gauge!("nexus_queue_depth").set(self.depth() as f64);
+// src/queue/mod.rs, lines 343–386
+
+fn make_config(max_size: u32, max_wait_seconds: u64) -> QueueConfig {
+    QueueConfig { enabled: true, max_size, max_wait_seconds }
+}
+
+fn make_intent() -> RoutingIntent {
+    RoutingIntent::new("req-1".to_string(), "llama3:8b".to_string(), ...)
+}
+
+fn make_request() -> ChatCompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": "llama3:8b",
+        "messages": [{"role": "user", "content": "hello"}]
+    })).unwrap()
+}
+
+fn make_queued(priority: Priority) -> (QueuedRequest, oneshot::Receiver<QueueResponse>) {
+    let (tx, rx) = oneshot::channel();
+    let req = QueuedRequest { intent: make_intent(), request: make_request(), response_tx: tx, enqueued_at: Instant::now(), priority };
+    (req, rx)
+}
 ```
 
-This is updated on every `enqueue()` and `try_dequeue()` call, giving real-time visibility into queue depth.
+`make_queued()` returns **both** the request and the receiver — the test can enqueue the request and then check whether a response was sent through the receiver.
 
-## 6. Testing
+### Test Organization
 
-### Unit Tests (13 tests in `src/queue/mod.rs`)
+| Group | Test Count | What It Covers |
+|-------|------------|----------------|
+| T021: Queue structure (unit) | 7 | FIFO ordering, capacity limits, priority ordering, depth accuracy, disabled/empty states |
+| T022: Timeout behavior (unit) | 3 | `Retry-After` header, timeout detection, timeout speed |
+| T028: Priority parsing (unit) | 3 | `from_header()` with valid, invalid, and edge-case inputs |
+| CAS correctness (unit) | 1 | 50 concurrent enqueues respect `max_size=10` |
+| T023: Integration | 2 | End-to-end capacity+overflow, mixed-priority drain ordering |
 
-| Test | What it verifies |
-|------|-----------------|
-| `fifo_ordering_normal_priority` | Normal-priority requests dequeue in FIFO order |
-| `capacity_limits_reject_when_full` | Enqueue fails with `QueueError::Full` at capacity |
-| `priority_ordering_high_drains_first` | High-priority dequeues before normal regardless of enqueue order |
-| `depth_accuracy` | `depth()` accurately reflects enqueue/dequeue operations |
-| `max_size_zero_rejects_immediately` | `max_size=0` treated as disabled → `QueueError::Disabled` |
-| `disabled_queue_rejects` | `enabled=false` → `QueueError::Disabled` |
-| `empty_dequeue_returns_none` | `try_dequeue()` on empty queue returns `None` |
-| `timeout_response_has_retry_after` | 503 response includes `Retry-After` header |
-| `enqueued_request_timeout_detection` | Elapsed time comparison correctly detects timeouts |
-| `timeout_completes_within_time_limit` | Timeout detection + oneshot response is fast |
-| `priority_from_header_high` | `"high"`, `"HIGH"`, `" High "` → `Priority::High` |
-| `priority_from_header_normal` | `"normal"`, `"NORMAL"` → `Priority::Normal` |
-| `priority_from_header_invalid_defaults_to_normal` | `""`, `"urgent"`, `"low"` → `Priority::Normal` |
+### Testing Patterns
 
-### Integration Tests (2 tests in `tests/queue_test.rs`)
+**Pattern 1: Enqueue → Dequeue → Assert Order**
 
-| Test | What it verifies |
-|------|-----------------|
-| `queue_accepts_up_to_capacity_and_rejects_overflow` | N requests accepted, N+1 rejected with `Full`, all N drain correctly |
-| `queue_drains_high_priority_first_integration` | Mixed-priority enqueue drains high first, then normal in FIFO |
-
-### Running the tests
-
-```bash
-# All queue tests (unit + integration)
-cargo test queue
-
-# Unit tests only
-cargo test queue::tests
-
-# Integration tests only
-cargo test --test queue_test
-
-# Single test
-cargo test priority_ordering_high_drains_first
-```
-
-## 7. Common Modifications
-
-### Changing the poll interval
-
-The 50ms interval is hardcoded in `queue_drain_loop()`:
+Most queue tests follow this shape: fill the queue in a known order, drain it, and verify the output order matches expectations.
 
 ```rust
-_ = tokio::time::sleep(Duration::from_millis(50)) => {
+#[tokio::test]
+async fn fifo_ordering_normal_priority() {
+    let queue = RequestQueue::new(make_config(10, 30));
+    // Enqueue with known timestamps
+    queue.enqueue(req1).unwrap();
+    queue.enqueue(req2).unwrap();
+    // Dequeue and verify order
+    let d1 = queue.try_dequeue().await.unwrap();
+    assert_eq!(d1.enqueued_at, t1);  // First in = first out
+}
 ```
 
-To make it configurable, add a `poll_interval_ms` field to `QueueConfig` and pass it through.
+**Pattern 2: Boundary Testing**
 
-### Adding a new priority level
+Queue tests systematically hit boundaries: exactly at capacity, one over capacity, zero capacity, disabled state.
 
-To add e.g. `Priority::Low`:
+```rust
+#[tokio::test]
+async fn capacity_limits_reject_when_full() {
+    let queue = RequestQueue::new(make_config(2, 30));  // max_size=2
+    queue.enqueue(req1).unwrap();  // 1/2 — OK
+    queue.enqueue(req2).unwrap();  // 2/2 — OK
+    let result = queue.enqueue(req3);  // 3/2 — FULL
+    assert!(matches!(result, Err(QueueError::Full { max_size: 2 })));
+}
+```
 
-1. Add the variant to `enum Priority` in `src/queue/mod.rs`
-2. Add a third `mpsc` channel pair in `RequestQueue::new()`
-3. Update `enqueue()` to route to the correct channel
-4. Update `try_dequeue()` to check high → normal → low
-5. Update `Priority::from_header()` to parse `"low"`
+**Pattern 3: Concurrent Stress Testing**
 
-### Monitoring queue health
+The CAS loop test uses `tokio::spawn` to create real concurrency, then counts successes to verify the atomic invariant holds under contention.
 
-Query the `nexus_queue_depth` Prometheus gauge at `/metrics`. A sustained non-zero depth indicates backends are saturated. Combine with `nexus_backend_pending_requests` to correlate queue depth with backend load.
+```rust
+#[tokio::test]
+async fn concurrent_enqueue_respects_max_size() {
+    // 50 tasks race to enqueue into max_size=10
+    let successes = results.iter().filter(|r| r.as_ref().unwrap().is_ok()).count();
+    assert_eq!(successes, 10, "Exactly max_size requests should succeed");
+}
+```
+
+---
+
+## Key Rust Concepts
+
+### 1. `compare_exchange` (CAS) for Lock-Free Atomics
+
+```rust
+self.depth.compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+```
+
+`compare_exchange` is the atomic equivalent of: "if the value is still what I think it is, update it; otherwise, tell me what it actually is." It takes four arguments: `current` (expected value), `new` (desired value), `success_ordering`, `failure_ordering`. Returns `Ok(previous)` on success or `Err(actual)` on failure. The CAS loop wrapping this retries until it succeeds or the capacity check fails.
+
+### 2. `oneshot::channel` for One-Time Response Delivery
+
+```rust
+let (tx, rx) = tokio::sync::oneshot::channel();
+// Handler holds rx, awaits it with timeout
+// Drain loop holds tx (inside QueuedRequest), sends response through it
+```
+
+A `oneshot` channel can send exactly one value. It's perfect for request-response patterns: the handler creates the channel, gives the sender to the queue, and awaits the receiver. When the drain loop processes the request, it sends the response and the handler unblocks. If the sender is dropped without sending (e.g., the drain loop panics), the receiver gets an error.
+
+### 3. `tokio::select!` for Concurrent Waiting
+
+```rust
+tokio::select! {
+    _ = cancel.cancelled() => { /* shutdown */ }
+    _ = tokio::time::sleep(Duration::from_millis(50)) => { /* poll queue */ }
+}
+```
+
+`select!` races multiple futures and executes the branch of whichever completes first. Here, it races the cancellation signal against a 50ms sleep. If cancellation fires during the sleep, the drain loop exits immediately without waiting for the full 50ms. This is how Nexus achieves responsive shutdown.
+
+### 4. `Arc<T>` for Shared Ownership Across Tasks
+
+```rust
+let queue = Arc::new(RequestQueue::new(config));
+let queue_clone = Arc::clone(&queue);
+tokio::spawn(async move { queue_drain_loop(queue_clone, ...).await; });
+```
+
+`Arc` (Atomic Reference Count) allows multiple owners of the same data. When the last `Arc` is dropped, the data is freed. The queue needs to be owned by both `AppState` (for the handler) and the drain loop task — `Arc` makes this possible without copying the queue.
+
+### 5. `Ordering::SeqCst` for Sequential Consistency
+
+```rust
+self.depth.load(Ordering::SeqCst);
+self.depth.compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst);
+```
+
+`SeqCst` (Sequentially Consistent) is the strongest memory ordering — it guarantees that all threads see atomic operations in the same order. It's slower than `Relaxed` or `Acquire`/`Release`, but for a queue depth counter that's checked on every enqueue, correctness matters more than nanoseconds. The queue processes at most ~20 requests/sec (bounded by the 50ms poll), so `SeqCst` overhead is negligible.
+
+---
+
+## Common Patterns in This Codebase
+
+### 1. The Dual-Channel Priority Pattern
+
+Instead of a single channel with a priority field and a sorted data structure:
+
+```
+                    ┌─── High Channel ───┐
+Request ──enqueue──►│  mpsc (try_send)   │──dequeue──► (checked first)
+                    └────────────────────┘
+                    ┌─── Normal Channel ──┐
+                    │  mpsc (try_send)    │──dequeue──► (checked second)
+                    └────────────────────┘
+```
+
+Priority is **structural**: two separate channels, always drain high first. This avoids sorting, custom comparators, and heap rebalancing. Adding a new priority level means adding a new channel pair — `O(1)` code change, `O(1)` runtime per enqueue/dequeue.
+
+### 2. The Oneshot Response Bridge Pattern
+
+The queue acts as a bridge between two execution contexts — the HTTP handler's synchronous request-response flow and the drain loop's asynchronous polling:
+
+```
+Handler Task                     Drain Loop Task
+─────────────                    ───────────────
+let (tx, rx) = oneshot()
+queue.enqueue(QueuedRequest{tx})
+                                 let req = queue.try_dequeue()
+                                 let response = agent.chat_completion()
+                                 req.response_tx.send(response)
+rx.await ◄── response arrives
+return response to client
+```
+
+The handler doesn't know or care when the drain loop runs. It just awaits the oneshot receiver. The drain loop doesn't know or care about HTTP. It just sends responses. The oneshot channel decouples them completely.
+
+### 3. The Graceful Drain Pattern
+
+On shutdown, long-lived background tasks need to clean up:
+
+```rust
+tokio::select! {
+    _ = cancel.cancelled() => {
+        drain_remaining(&queue).await;  // Notify all waiting clients
+        break;
+    }
+    _ = sleep(50ms) => { /* normal work */ }
+}
+```
+
+The `CancellationToken` propagates shutdown through the entire system. Each component handles it by cleaning up its own resources. The queue's cleanup is `drain_remaining()` — it dequeues every request and sends a 503, so no HTTP handler is left hanging forever.
+
+### 4. The Rollback-on-Failure Pattern
+
+Atomic operations that can fail use a rollback strategy:
+
+```rust
+// Reserve a slot (optimistic)
+self.depth.compare_exchange(current, current + 1, ...);
+
+// Try the actual operation
+if tx.try_send(request).is_err() {
+    // Rollback the reservation
+    self.depth.fetch_sub(1, Ordering::SeqCst);
+    return Err(QueueError::Full { ... });
+}
+```
+
+This is a lightweight form of transaction: increment first (optimistic), attempt the real work, undo the increment on failure. It keeps the depth counter accurate even when channel sends fail.
+
+---
+
+## Next Steps
+
+After understanding F18, here's what to explore next:
+
+1. **`src/routing/mod.rs`** — Find where `RoutingError::Queue` is produced. Look at `select_backend()` and how `queue_enabled` influences the decision between `Queue` and `NoBackend`.
+
+2. **F15: Speculative Router** — The `RequestRequirements` struct that the drain loop uses when re-running `select_backend()` (see `specs/018-speculative-router/walkthrough.md`).
+
+3. **Metrics** — The `nexus_queue_depth` gauge at `/metrics`. Try watching it during a load test to see the queue fill and drain in real time.
+
+4. **Try it yourself**: Set `max_size=2` in config, send 5 concurrent requests to saturated backends, and observe which get queued, which get rejected, and what the `Retry-After` header says.
+
+### Questions to Investigate
+
+- What happens if the drain loop dequeues a request, but the handler's `tokio::time::timeout` already expired? (Hint: `response_tx.send()` returns `Err` because the receiver was dropped — the `let _ =` silently ignores this)
+- Why does re-enqueue preserve the original `enqueued_at` instead of resetting it? (Hint: resetting would let a request bounce in the queue forever, never timing out)
+- How would you add a `Priority::Low` level? (Hint: add a third `mpsc` channel pair, update `enqueue()`/`try_dequeue()`/`from_header()`, and add a new dequeue check after normal)
+- Why use `SeqCst` ordering instead of `Acquire`/`Release`? (Hint: correctness over performance — the queue processes ~20 requests/sec max, so the overhead is negligible)


### PR DESCRIPTION
## Spec Artifact Consistency Audit

Pre-release quality pass ensuring all v0.4 spec artifacts are consistent and accurate.

### Walkthrough Rewrites
Both F17 and F18 walkthroughs were rewritten from scratch to match the gold-standard structure established by F15/F16 (specs 018/019).

**F17 Embeddings API** (378 → 906 lines):
- Added: Table of Contents, Big Picture, File Structure, Understanding the Tests, Key Rust Concepts, Common Patterns, Next Steps
- Translation bureau metaphor used throughout
- All code snippets updated to reflect red team fixes (model param forwarding, batch size limit, pending tracking, X-Nexus-* headers)

**F18 Request Queuing** (420 → 1019 lines):
- Same structural alignment with gold standard
- Hospital ER metaphor used throughout
- Code snippets updated to show CAS loop fix (compare_exchange, not load+check+fetch_add)

### Data Accuracy Fixes
- F18 line count: 595 → 632 across 5 files (spec.md, tasks.md, plan.md, README.md, checklists/requirements.md)
- F18 total LOC: 822 → 859 in tasks.md

### Verification
- All code snippets verified against actual source files
- All test counts verified (F17: 8+5, F18: 14+2)
- All structural sections from gold standard present